### PR TITLE
Lettermint transport

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -163,6 +163,8 @@ jobs:
       with:
         node-version: '24'
     - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: '1.2.22'
     - uses: pnpm/action-setup@v4
       with:
         version: latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,6 +39,9 @@ jobs:
       SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
       SENDGRID_FROM: ${{ secrets.SENDGRID_FROM }}
       SENDGRID_TO: ${{ secrets.SENDGRID_TO }}
+      LETTERMINT_API_TOKEN: ${{ secrets.LETTERMINT_API_TOKEN }}
+      LETTERMINT_FROM: ${{ secrets.LETTERMINT_FROM }}
+      LETTERMINT_TO: ${{ secrets.LETTERMINT_TO }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -91,6 +94,9 @@ jobs:
       SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
       SENDGRID_FROM: ${{ secrets.SENDGRID_FROM }}
       SENDGRID_TO: ${{ secrets.SENDGRID_TO }}
+      LETTERMINT_API_TOKEN: ${{ secrets.LETTERMINT_API_TOKEN }}
+      LETTERMINT_FROM: ${{ secrets.LETTERMINT_FROM }}
+      LETTERMINT_TO: ${{ secrets.LETTERMINT_TO }}
     steps:
     - uses: actions/checkout@v4
     - uses: denoland/setup-deno@v2
@@ -148,6 +154,9 @@ jobs:
       SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
       SENDGRID_FROM: ${{ secrets.SENDGRID_FROM }}
       SENDGRID_TO: ${{ secrets.SENDGRID_TO }}
+      LETTERMINT_API_TOKEN: ${{ secrets.LETTERMINT_API_TOKEN }}
+      LETTERMINT_FROM: ${{ secrets.LETTERMINT_FROM }}
+      LETTERMINT_TO: ${{ secrets.LETTERMINT_TO }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ functions.  It's structured as a monorepo with multiple packages:
 
  -  *@upyo/core*: Shared types and interfaces for email messages
  -  *@upyo/smtp*: SMTP transport implementation
+ -  *@upyo/lettermint*: Lettermint transport implementation
  -  *@upyo/mailgun*: Mailgun transport implementation
  -  *@upyo/sendgrid*: SendGrid transport implementation
  -  *@upyo/ses*: Amazon SES transport implementation
@@ -270,6 +271,8 @@ the application.
 
  -  *@upyo/smtp*: Full-featured SMTP client with connection pooling, TLS
     support, and authentication
+ -  *@upyo/lettermint*: Lettermint HTTP API transport with idempotency, batch
+    sending, routes, tags, metadata, and tracking settings
  -  *@upyo/mailgun*: Mailgun HTTP API transport with support for US/EU regions
     and batch operations
  -  *@upyo/sendgrid*: SendGrid HTTP API transport with template support and
@@ -288,8 +291,8 @@ the application.
 
  -  *SMTP*: Direct protocol implementation, works with any SMTP server,
     supports connection reuse
- -  *HTTP-based* (Mailgun, SendGrid, SES): Stateless, simpler configuration,
-    provider-specific features
+ -  *HTTP-based* (Lettermint, Mailgun, SendGrid, SES): Stateless, simpler
+    configuration, provider-specific features
  -  *Mock*: In-memory storage, failure simulation, comprehensive testing
     utilities
  -  *OpenTelemetry*: Transparent wrapper, metrics collection, distributed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,26 @@ Version 0.5.0
 
 To be released.
 
+### @upyo/lettermint
+
+ -  Added [Lettermint] transport.  [[#22], [#23]]
+
+     -  Added `LettermintTransport` class.
+     -  Added `LettermintConfig` interface.
+     -  Added `ResolvedLettermintConfig` type.
+     -  Added `LettermintSettings` interface.
+     -  Added `LettermintApiError` class.
+     -  Added `LettermintBatchResponse` type.
+     -  Added `LettermintError` interface.
+     -  Added `LettermintResponse` interface.
+     -  Added `LettermintStatus` type.
+     -  Supports single sends, batch sends, idempotency keys, attachments,
+        inline images, routes, tags, metadata, and tracking settings.
+
+[Lettermint]: https://lettermint.co/
+[#22]: https://github.com/dahlia/upyo/issues/22
+[#23]: https://github.com/dahlia/upyo/pull/23
+
 
 Version 0.4.0
 -------------

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Upyo
 
 Upyo is a cross-runtime email library that provides a unified, type-safe API
 for sending emails across Node.js, Deno, Bun, and edge functions. Switch
-between SMTP and HTTP-based providers (Mailgun, Resend, SendGrid, Amazon SES)
-without changing your application code, while enjoying full TypeScript support,
-consistent error handling, and built-in testing capabilities with mock
-transports across all runtimes.
+between SMTP and HTTP-based providers (Lettermint, Mailgun, Resend, SendGrid,
+Amazon SES) without changing your application code, while enjoying full
+TypeScript support, consistent error handling, and built-in testing
+capabilities with mock transports across all runtimes.
 
 Here's a quick demo of sending an email using the Mailgun transport:
 
@@ -69,6 +69,7 @@ sending messages.  The following is a list of the available packages:
 | [@upyo/core](/packages/core/)                   | [JSR][jsr:@upyo/core]          | [npm][npm:@upyo/core]          | Shared types and interfaces for email messages     |
 | [@upyo/smtp](/packages/smtp/)                   | [JSR][jsr:@upyo/smtp]          | [npm][npm:@upyo/smtp]          | SMTP transport                                     |
 | [@upyo/jmap](/packages/jmap/)                   | [JSR][jsr:@upyo/jmap]          | [npm][npm:@upyo/jmap]          | [JMAP] transport (RFC 8620/8621)                   |
+| [@upyo/lettermint](/packages/lettermint/)       | [JSR][jsr:@upyo/lettermint]    | [npm][npm:@upyo/lettermint]    | [Lettermint] transport                             |
 | [@upyo/mailgun](/packages/mailgun/)             | [JSR][jsr:@upyo/mailgun]       | [npm][npm:@upyo/mailgun]       | [Mailgun] transport                                |
 | [@upyo/plunk](/packages/plunk/)                 | [JSR][jsr:@upyo/plunk]         | [npm][npm:@upyo/plunk]         | [Plunk] transport                                  |
 | [@upyo/resend](/packages/resend/)               | [JSR][jsr:@upyo/resend]        | [npm][npm:@upyo/resend]        | [Resend] transport                                 |
@@ -84,6 +85,9 @@ sending messages.  The following is a list of the available packages:
 [jsr:@upyo/jmap]: https://jsr.io/@upyo/jmap
 [npm:@upyo/jmap]: https://www.npmjs.com/package/@upyo/jmap
 [JMAP]: https://jmap.io/
+[jsr:@upyo/lettermint]: https://jsr.io/@upyo/lettermint
+[npm:@upyo/lettermint]: https://www.npmjs.com/package/@upyo/lettermint
+[Lettermint]: https://lettermint.co/
 [jsr:@upyo/mailgun]: https://jsr.io/@upyo/mailgun
 [npm:@upyo/mailgun]: https://www.npmjs.com/package/@upyo/mailgun
 [Mailgun]: https://www.mailgun.com/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,6 +13,7 @@ import llmstxt from "vitepress-plugin-llms";
 const packages: readonly string[] = [
   "core",
   "jmap",
+  "lettermint",
   "mailgun",
   "plunk",
   "resend",
@@ -73,6 +74,7 @@ const NAV = [
     items: [
       { text: "SMTP", link: "/transports/smtp" },
       { text: "JMAP", link: "/transports/jmap" },
+      { text: "Lettermint", link: "/transports/lettermint" },
       { text: "Mailgun", link: "/transports/mailgun" },
       { text: "Plunk", link: "/transports/plunk" },
       { text: "Resend", link: "/transports/resend" },
@@ -90,6 +92,7 @@ const NAV = [
       { text: "@upyo/core", link: "https://jsr.io/@upyo/core/doc" },
       { text: "@upyo/smtp", link: "https://jsr.io/@upyo/smtp/doc" },
       { text: "@upyo/jmap", link: "https://jsr.io/@upyo/jmap/doc" },
+      { text: "@upyo/lettermint", link: "https://jsr.io/@upyo/lettermint/doc" },
       { text: "@upyo/mailgun", link: "https://jsr.io/@upyo/mailgun/doc" },
       { text: "@upyo/plunk", link: "https://jsr.io/@upyo/plunk/doc" },
       { text: "@upyo/resend", link: "https://jsr.io/@upyo/resend/doc" },

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,7 @@
     "@types/node": "^24.0.13",
     "@upyo/core": "workspace:",
     "@upyo/jmap": "workspace:",
+    "@upyo/lettermint": "workspace:",
     "@upyo/mailgun": "workspace:",
     "@upyo/mock": "workspace:",
     "@upyo/opentelemetry": "workspace:",

--- a/docs/start.md
+++ b/docs/start.md
@@ -53,6 +53,10 @@ strengths and use cases:
 [Mailgun](./transports/mailgun.md)
 :   HTTP API service with advanced features and analytics
 
+[Lettermint](./transports/lettermint.md)
+:   Transactional email API with routes, metadata, idempotency, and batch
+    sending
+
 [Resend](./transports/resend.md)
 :   Modern email service provider that offers a developer-friendly API
 

--- a/docs/transports/lettermint.md
+++ b/docs/transports/lettermint.md
@@ -173,9 +173,10 @@ for await (const receipt of transport.sendMany(messages)) {
 }
 ~~~~
 
-For batch sends, the first message's `idempotencyKey` is used as the
-`Idempotency-Key` request header. If the first message has no key, the
-transport generates one for the batch request.
+For batch sends, messages without `idempotencyKey` values are grouped into
+Lettermint batch requests with generated request idempotency keys. If any
+message has an `idempotencyKey`, `sendMany()` sends that chunk through the
+single-message API instead so each message's key is preserved.
 
 
 Idempotency and reliability

--- a/docs/transports/lettermint.md
+++ b/docs/transports/lettermint.md
@@ -1,0 +1,250 @@
+---
+description: >-
+  Learn how to send emails with Lettermint transport, including batch sending,
+  idempotency, routes, metadata, tracking settings, and inline attachments.
+---
+
+Lettermint
+==========
+
+*This transport is introduced in Upyo 0.5.0.*
+
+[Lettermint] is a transactional email provider with a straightforward HTTP
+API for sending emails. It supports common email fields such as recipients,
+HTML and text content, reply-to addresses, custom headers, attachments, and
+inline images, plus provider-specific features such as routes, tags, metadata,
+tracking settings, and idempotency keys.
+
+Upyo provides the Lettermint transport through the *@upyo/lettermint* package.
+It supports single sends, batch sends of up to 500 messages per request,
+attachments, idempotency, retry logic, and `AbortSignal` cancellation.
+
+[Lettermint]: https://lettermint.co/
+
+
+Installation
+------------
+
+To use the Lettermint transport, install the *@upyo/lettermint* package:
+
+::: code-group
+
+~~~~ sh [npm]
+npm add @upyo/lettermint
+~~~~
+
+~~~~ sh [pnpm]
+pnpm add @upyo/lettermint
+~~~~
+
+~~~~ sh [Yarn]
+yarn add @upyo/lettermint
+~~~~
+
+~~~~ sh [Deno]
+deno add jsr:@upyo/lettermint
+~~~~
+
+~~~~ sh [Bun]
+bun add @upyo/lettermint
+~~~~
+
+:::
+
+
+Getting started
+---------------
+
+Before using the Lettermint transport, you'll need a Lettermint project and a
+sending API token. The token is sent to Lettermint as the
+`x-lettermint-token` request header.
+
+~~~~ typescript twoslash
+import { createMessage } from "@upyo/core";
+import { LettermintTransport } from "@upyo/lettermint";
+
+const transport = new LettermintTransport({
+  apiToken: "lm_project_1234567890abcdef",
+});
+
+const message = createMessage({
+  from: "support@example.com",
+  to: "customer@example.com",
+  subject: "Welcome to our service",
+  content: { text: "Thank you for signing up!" },
+});
+
+const receipt = await transport.send(message);
+if (receipt.successful) {
+  console.log("Message sent with ID:", receipt.messageId);
+} else {
+  console.error("Send failed:", receipt.errorMessages.join(", "));
+}
+~~~~
+
+The transport converts Upyo messages to Lettermint's JSON format and sends
+them through the `/v1/send` endpoint. HTML and text alternatives, CC, BCC,
+reply-to, custom headers, priority, attachments, and inline Content-ID
+attachments are handled automatically.
+
+
+Routes, tags, metadata, and tracking
+------------------------------------
+
+Lettermint supports provider-specific fields for categorizing and routing
+messages. Configure defaults on the transport when every message sent through
+that transport should share the same route, metadata, or tracking settings:
+
+~~~~ typescript twoslash
+import { createMessage } from "@upyo/core";
+import { LettermintTransport } from "@upyo/lettermint";
+
+const transport = new LettermintTransport({
+  apiToken: "lm_project_1234567890abcdef",
+  route: "transactional",
+  tag: "welcome",
+  metadata: {
+    environment: "production",
+    service: "accounts",
+  },
+  settings: {
+    trackOpens: false,
+    trackClicks: true,
+  },
+});
+
+const message = createMessage({
+  from: "onboarding@example.com",
+  to: "newuser@example.com",
+  subject: "Welcome to our platform",
+  content: {
+    html: "<h1>Welcome!</h1><p>Thank you for joining us.</p>",
+    text: "Welcome! Thank you for joining us.",
+  },
+});
+
+await transport.send(message);
+~~~~
+
+Lettermint accepts one tag per message. If a message has exactly one
+`Message.tags` value, that tag overrides the transport's default `tag`. If it
+has more than one tag, the transport returns a failed receipt instead of
+sending the message.
+
+
+Batch sending
+-------------
+
+The `sendMany()` method uses Lettermint's batch endpoint and automatically
+splits large inputs into chunks of 500 messages:
+
+~~~~ typescript twoslash
+import { createMessage } from "@upyo/core";
+import { LettermintTransport } from "@upyo/lettermint";
+
+const transport = new LettermintTransport({
+  apiToken: "lm_project_1234567890abcdef",
+});
+
+const recipients = [
+  "user1@example.com",
+  "user2@example.com",
+  "user3@example.com",
+];
+
+const messages = recipients.map(email =>
+  createMessage({
+    from: "updates@example.com",
+    to: email,
+    subject: "Monthly update",
+    content: {
+      html: "<h2>This month's updates</h2><p>Here's what's new.</p>",
+      text: "This month's updates\n\nHere's what's new.",
+    },
+  })
+);
+
+for await (const receipt of transport.sendMany(messages)) {
+  if (receipt.successful) {
+    console.log(`Email sent with ID: ${receipt.messageId}`);
+  } else {
+    console.error(`Failed to send: ${receipt.errorMessages.join(", ")}`);
+  }
+}
+~~~~
+
+For batch sends, the first message's `idempotencyKey` is used as the
+`Idempotency-Key` request header. If the first message has no key, the
+transport generates one for the batch request.
+
+
+Idempotency and reliability
+---------------------------
+
+Lettermint supports the `Idempotency-Key` HTTP header to prevent duplicate
+sends during retries. Upyo maps `Message.idempotencyKey` to that header:
+
+~~~~ typescript twoslash
+import { createMessage } from "@upyo/core";
+import { LettermintTransport } from "@upyo/lettermint";
+
+const transport = new LettermintTransport({
+  apiToken: "lm_project_1234567890abcdef",
+  retries: 3,
+  timeout: 30000,
+});
+
+const message = createMessage({
+  from: "alerts@example.com",
+  to: "admin@example.com",
+  subject: "System alert",
+  content: { text: "CPU usage has exceeded 90%." },
+  priority: "high",
+  idempotencyKey: "alert-cpu-2026-05-17T10:00Z",
+});
+
+await transport.send(message);
+~~~~
+
+The transport retries temporary failures with exponential backoff. Client
+errors from Lettermint are returned as failed receipts without retrying, and
+`AbortSignal` cancellation is supported through Upyo's standard transport
+options.
+
+
+Attachments and inline images
+-----------------------------
+
+Attachments are encoded as base64 before being sent to Lettermint. Inline
+attachments include their `content_id` so HTML content can reference them with
+`cid:` URLs:
+
+~~~~ typescript twoslash
+import { createMessage } from "@upyo/core";
+import { LettermintTransport } from "@upyo/lettermint";
+
+const transport = new LettermintTransport({
+  apiToken: "lm_project_1234567890abcdef",
+});
+
+const logo = new TextEncoder().encode("fake image bytes");
+
+const message = createMessage({
+  from: "brand@example.com",
+  to: "customer@example.com",
+  subject: "Welcome",
+  content: {
+    html: '<h1>Welcome</h1><img src="cid:logo" alt="Logo">',
+    text: "Welcome",
+  },
+  attachments: [{
+    filename: "logo.png",
+    content: logo,
+    contentType: "image/png",
+    inline: true,
+    contentId: "logo",
+  }],
+});
+
+await transport.send(message);
+~~~~

--- a/packages/lettermint/.env.example
+++ b/packages/lettermint/.env.example
@@ -1,0 +1,7 @@
+# Lettermint E2E Test Configuration
+# Uncomment and fill these values to enable E2E testing
+
+# LETTERMINT_API_TOKEN=your-lettermint-api-token
+# LETTERMINT_BASE_URL=https://api.lettermint.co
+# LETTERMINT_FROM=from@example.com
+# LETTERMINT_TO=to@example.com

--- a/packages/lettermint/README.md
+++ b/packages/lettermint/README.md
@@ -1,0 +1,106 @@
+<!-- deno-fmt-ignore-file -->
+
+@upyo/lettermint
+================
+
+[![JSR][JSR badge]][JSR]
+[![npm][npm badge]][npm]
+
+[Lettermint] transport for the [Upyo] email library.
+
+[JSR badge]: https://jsr.io/badges/@upyo/lettermint
+[JSR]: https://jsr.io/@upyo/lettermint
+[npm badge]: https://img.shields.io/npm/v/@upyo/lettermint?logo=npm
+[npm]: https://www.npmjs.com/package/@upyo/lettermint
+[Lettermint]: https://lettermint.co/
+[Upyo]: https://upyo.org/
+
+
+Features
+--------
+
+ -  Single and batch email sending via Lettermint's HTTP API
+ -  Idempotency key support through `Message.idempotencyKey`
+ -  Cross-runtime compatibility (Node.js, Deno, Bun, edge functions)
+ -  Rich content support: HTML emails, attachments, inline images, and custom
+    headers
+ -  Lettermint route, tag, metadata, and tracking settings
+ -  Retry logic with exponential backoff
+ -  Type-safe configuration with sensible defaults
+
+
+Installation
+------------
+
+~~~~ sh
+npm  add       @upyo/core @upyo/lettermint
+pnpm add       @upyo/core @upyo/lettermint
+yarn add       @upyo/core @upyo/lettermint
+deno add --jsr @upyo/core @upyo/lettermint
+bun  add       @upyo/core @upyo/lettermint
+~~~~
+
+
+Usage
+-----
+
+~~~~ typescript
+import { createMessage } from "@upyo/core";
+import { LettermintTransport } from "@upyo/lettermint";
+import process from "node:process";
+
+const message = createMessage({
+  from: "sender@example.com",
+  to: "recipient@example.net",
+  subject: "Hello from Upyo!",
+  content: { text: "This is a test email." },
+  idempotencyKey: "welcome-recipient-example-net",
+});
+
+const transport = new LettermintTransport({
+  apiToken: process.env.LETTERMINT_API_TOKEN!,
+});
+
+const receipt = await transport.send(message);
+if (receipt.successful) {
+  console.log("Message sent with ID:", receipt.messageId);
+} else {
+  console.error("Send failed:", receipt.errorMessages.join(", "));
+}
+~~~~
+
+### Sending multiple emails
+
+~~~~ typescript
+const messages = [message1, message2, message3];
+
+for await (const receipt of transport.sendMany(messages)) {
+  if (receipt.successful) {
+    console.log(`Email sent with ID: ${receipt.messageId}`);
+  } else {
+    console.error(`Email failed: ${receipt.errorMessages.join(", ")}`);
+  }
+}
+~~~~
+
+
+Configuration
+-------------
+
+See the [Lettermint docs] for more information about configuration options.
+
+[Lettermint docs]: https://docs.lettermint.co/
+
+### Available options
+
+ -  `apiToken`: Your Lettermint project sending API token
+ -  `baseUrl`: Lettermint API base URL (default:
+    `https://api.lettermint.co`)
+ -  `timeout`: Request timeout in milliseconds (default: `30000`)
+ -  `retries`: Number of retry attempts (default: `3`)
+ -  `validateSsl`: Whether to validate SSL certificates (default: `true`)
+ -  `headers`: Additional HTTP headers
+ -  `route`: Lettermint route for sent messages
+ -  `tag`: Default Lettermint tag when a message has no `Message.tags`
+ -  `metadata`: Metadata to track with sent messages
+ -  `settings`: Lettermint tracking settings (`trackOpens`, `trackClicks`)

--- a/packages/lettermint/README.md
+++ b/packages/lettermint/README.md
@@ -98,7 +98,6 @@ See the [Lettermint docs] for more information about configuration options.
     `https://api.lettermint.co`)
  -  `timeout`: Request timeout in milliseconds (default: `30000`)
  -  `retries`: Number of retry attempts (default: `3`)
- -  `validateSsl`: Whether to validate SSL certificates (default: `true`)
  -  `headers`: Additional HTTP headers
  -  `route`: Lettermint route for sent messages
  -  `tag`: Default Lettermint tag when a message has no `Message.tags`

--- a/packages/lettermint/deno.json
+++ b/packages/lettermint/deno.json
@@ -1,0 +1,32 @@
+{
+  "name": "@upyo/lettermint",
+  "version": "0.5.0",
+  "license": "MIT",
+  "exports": "./src/index.ts",
+  "exclude": [
+    "dist/"
+  ],
+  "tasks": {
+    "build": "pnpm build",
+    "test": "deno test --allow-env --allow-net --env-file=.env",
+    "test:node": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "pnpm exec dotenvx run --ignore=MISSING_ENV_FILE -- node --experimental-transform-types --test"
+    },
+    "test:bun": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "bun test --timeout=30000 --env-file=.env"
+    },
+    "test-all": {
+      "dependencies": [
+        "test",
+        "test:node",
+        "test:bun"
+      ]
+    }
+  }
+}

--- a/packages/lettermint/package.json
+++ b/packages/lettermint/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@upyo/lettermint",
+  "version": "0.5.0",
+  "description": "Lettermint transport for Upyo email library",
+  "keywords": [
+    "email",
+    "mail",
+    "sendmail",
+    "lettermint"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Hong Minhee",
+    "email": "hong@minhee.org",
+    "url": "https://hongminhee.org/"
+  },
+  "homepage": "https://upyo.org/transports/lettermint",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dahlia/upyo.git",
+    "directory": "packages/lettermint/"
+  },
+  "bugs": {
+    "url": "https://github.com/dahlia/upyo/issues"
+  },
+  "funding": [
+    "https://github.com/sponsors/dahlia"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "bun": ">=1.2.0",
+    "deno": ">=2.3.0"
+  },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "peerDependencies": {
+    "@upyo/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@dotenvx/dotenvx": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "tsdown",
+    "prepublish": "tsdown",
+    "test": "tsdown && dotenvx run --ignore=MISSING_ENV_FILE -- node --experimental-transform-types --test",
+    "test:bun": "tsdown && bun test --timeout=30000 --env-file=.env",
+    "test:deno": "deno test --allow-env --allow-net --env-file=.env"
+  }
+}

--- a/packages/lettermint/src/config.test.ts
+++ b/packages/lettermint/src/config.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createLettermintConfig, type LettermintConfig } from "./config.ts";
+
+describe("createLettermintConfig", () => {
+  it("applies default values to optional fields", () => {
+    const config: LettermintConfig = {
+      apiToken: "test-token",
+    };
+
+    const resolved = createLettermintConfig(config);
+
+    assert.equal(resolved.apiToken, "test-token");
+    assert.equal(resolved.baseUrl, "https://api.lettermint.co");
+    assert.equal(resolved.timeout, 30000);
+    assert.equal(resolved.retries, 3);
+    assert.equal(resolved.validateSsl, true);
+    assert.deepEqual(resolved.headers, {});
+    assert.equal(resolved.route, undefined);
+    assert.equal(resolved.tag, undefined);
+    assert.equal(resolved.metadata, undefined);
+    assert.equal(resolved.settings, undefined);
+  });
+
+  it("preserves provided optional values", () => {
+    const config: LettermintConfig = {
+      apiToken: "test-token",
+      baseUrl: "https://lettermint.example.com",
+      timeout: 60000,
+      retries: 5,
+      validateSsl: false,
+      headers: { "X-Custom": "value" },
+      route: "transactional",
+      tag: "welcome",
+      metadata: { campaign_id: "welcome-2026" },
+      settings: {
+        trackOpens: false,
+        trackClicks: true,
+      },
+    };
+
+    const resolved = createLettermintConfig(config);
+
+    assert.equal(resolved.apiToken, "test-token");
+    assert.equal(resolved.baseUrl, "https://lettermint.example.com");
+    assert.equal(resolved.timeout, 60000);
+    assert.equal(resolved.retries, 5);
+    assert.equal(resolved.validateSsl, false);
+    assert.deepEqual(resolved.headers, { "X-Custom": "value" });
+    assert.equal(resolved.route, "transactional");
+    assert.equal(resolved.tag, "welcome");
+    assert.deepEqual(resolved.metadata, { campaign_id: "welcome-2026" });
+    assert.deepEqual(resolved.settings, {
+      trackOpens: false,
+      trackClicks: true,
+    });
+  });
+
+  it("preserves zero timeout and retry values", () => {
+    const resolved = createLettermintConfig({
+      apiToken: "test-token",
+      timeout: 0,
+      retries: 0,
+    });
+
+    assert.equal(resolved.timeout, 0);
+    assert.equal(resolved.retries, 0);
+  });
+});

--- a/packages/lettermint/src/config.test.ts
+++ b/packages/lettermint/src/config.test.ts
@@ -14,7 +14,6 @@ describe("createLettermintConfig", () => {
     assert.equal(resolved.baseUrl, "https://api.lettermint.co");
     assert.equal(resolved.timeout, 30000);
     assert.equal(resolved.retries, 3);
-    assert.equal(resolved.validateSsl, true);
     assert.deepEqual(resolved.headers, {});
     assert.equal(resolved.route, undefined);
     assert.equal(resolved.tag, undefined);
@@ -28,7 +27,6 @@ describe("createLettermintConfig", () => {
       baseUrl: "https://lettermint.example.com",
       timeout: 60000,
       retries: 5,
-      validateSsl: false,
       headers: { "X-Custom": "value" },
       route: "transactional",
       tag: "welcome",
@@ -45,7 +43,6 @@ describe("createLettermintConfig", () => {
     assert.equal(resolved.baseUrl, "https://lettermint.example.com");
     assert.equal(resolved.timeout, 60000);
     assert.equal(resolved.retries, 5);
-    assert.equal(resolved.validateSsl, false);
     assert.deepEqual(resolved.headers, { "X-Custom": "value" });
     assert.equal(resolved.route, "transactional");
     assert.equal(resolved.tag, "welcome");

--- a/packages/lettermint/src/config.test.ts
+++ b/packages/lettermint/src/config.test.ts
@@ -63,4 +63,13 @@ describe("createLettermintConfig", () => {
     assert.equal(resolved.timeout, 0);
     assert.equal(resolved.retries, 0);
   });
+
+  it("normalizes trailing slashes from the base URL", () => {
+    const resolved = createLettermintConfig({
+      apiToken: "test-token",
+      baseUrl: "https://lettermint.example.com///",
+    });
+
+    assert.equal(resolved.baseUrl, "https://lettermint.example.com");
+  });
 });

--- a/packages/lettermint/src/config.ts
+++ b/packages/lettermint/src/config.ts
@@ -64,13 +64,6 @@ export interface LettermintConfig {
   readonly retries?: number;
 
   /**
-   * Whether to validate SSL certificates.
-   *
-   * @default true
-   */
-  readonly validateSsl?: boolean;
-
-  /**
    * Additional HTTP headers to include with requests.
    */
   readonly headers?: Record<string, string>;
@@ -128,7 +121,6 @@ export function createLettermintConfig(
     baseUrl: config.baseUrl ?? "https://api.lettermint.co",
     timeout: config.timeout ?? 30000,
     retries: config.retries ?? 3,
-    validateSsl: config.validateSsl ?? true,
     headers: config.headers ?? {},
     route: config.route,
     tag: config.tag,

--- a/packages/lettermint/src/config.ts
+++ b/packages/lettermint/src/config.ts
@@ -118,7 +118,7 @@ export function createLettermintConfig(
 ): ResolvedLettermintConfig {
   return {
     apiToken: config.apiToken,
-    baseUrl: config.baseUrl ?? "https://api.lettermint.co",
+    baseUrl: normalizeBaseUrl(config.baseUrl ?? "https://api.lettermint.co"),
     timeout: config.timeout ?? 30000,
     retries: config.retries ?? 3,
     headers: config.headers ?? {},
@@ -127,4 +127,8 @@ export function createLettermintConfig(
     metadata: config.metadata == null ? undefined : { ...config.metadata },
     settings: config.settings == null ? undefined : { ...config.settings },
   };
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
 }

--- a/packages/lettermint/src/config.ts
+++ b/packages/lettermint/src/config.ts
@@ -1,0 +1,138 @@
+/**
+ * Per-email Lettermint tracking settings.
+ *
+ * These settings are sent as provider-specific defaults for every message
+ * delivered through a {@link LettermintTransport}.
+ *
+ * @since 0.5.0
+ */
+export interface LettermintSettings {
+  /**
+   * Whether Lettermint should track email opens.
+   */
+  readonly trackOpens?: boolean;
+
+  /**
+   * Whether Lettermint should track link clicks.
+   */
+  readonly trackClicks?: boolean;
+}
+
+/**
+ * Configuration interface for Lettermint transport connection settings.
+ *
+ * @example
+ * ```typescript
+ * const config: LettermintConfig = {
+ *   apiToken: "your-project-api-token",
+ *   route: "transactional",
+ *   tag: "welcome",
+ *   timeout: 30000,
+ *   retries: 3,
+ * };
+ * ```
+ *
+ * @since 0.5.0
+ */
+export interface LettermintConfig {
+  /**
+   * Your project-specific Lettermint sending API token.
+   *
+   * The token is sent as the `x-lettermint-token` HTTP header.
+   */
+  readonly apiToken: string;
+
+  /**
+   * Base URL for the Lettermint API.
+   *
+   * @default "https://api.lettermint.co"
+   */
+  readonly baseUrl?: string;
+
+  /**
+   * HTTP request timeout in milliseconds.
+   *
+   * @default 30000
+   */
+  readonly timeout?: number;
+
+  /**
+   * Number of retry attempts for failed requests.
+   *
+   * @default 3
+   */
+  readonly retries?: number;
+
+  /**
+   * Whether to validate SSL certificates.
+   *
+   * @default true
+   */
+  readonly validateSsl?: boolean;
+
+  /**
+   * Additional HTTP headers to include with requests.
+   */
+  readonly headers?: Record<string, string>;
+
+  /**
+   * Lettermint route to apply to sent messages.
+   */
+  readonly route?: string;
+
+  /**
+   * Default Lettermint tag to apply when the Upyo message has no tag.
+   */
+  readonly tag?: string | null;
+
+  /**
+   * Metadata to track with sent messages.  This metadata is not added as
+   * email headers.
+   */
+  readonly metadata?: Record<string, string>;
+
+  /**
+   * Lettermint tracking settings to apply to sent messages.
+   */
+  readonly settings?: LettermintSettings;
+}
+
+/**
+ * Resolved Lettermint configuration with defaults applied.
+ *
+ * @since 0.5.0
+ */
+export type ResolvedLettermintConfig =
+  & Required<
+    Omit<LettermintConfig, "route" | "tag" | "metadata" | "settings">
+  >
+  & {
+    readonly route?: string;
+    readonly tag?: string | null;
+    readonly metadata?: Record<string, string>;
+    readonly settings?: LettermintSettings;
+  };
+
+/**
+ * Creates a resolved Lettermint configuration by applying default values.
+ *
+ * @param config The Lettermint configuration with optional fields.
+ * @returns A resolved configuration with all defaults applied.
+ * @since 0.5.0
+ */
+export function createLettermintConfig(
+  config: LettermintConfig,
+): ResolvedLettermintConfig {
+  return {
+    apiToken: config.apiToken,
+    baseUrl: config.baseUrl ?? "https://api.lettermint.co",
+    timeout: config.timeout ?? 30000,
+    retries: config.retries ?? 3,
+    validateSsl: config.validateSsl ?? true,
+    headers: config.headers ?? {},
+    route: config.route,
+    tag: config.tag,
+    metadata: config.metadata == null ? undefined : { ...config.metadata },
+    settings: config.settings == null ? undefined : { ...config.settings },
+  };
+}

--- a/packages/lettermint/src/http-client.ts
+++ b/packages/lettermint/src/http-client.ts
@@ -191,7 +191,8 @@ export class LettermintHttpClient {
         if (
           error instanceof LettermintApiError &&
           error.statusCode >= 400 &&
-          error.statusCode < 500
+          error.statusCode < 500 &&
+          error.statusCode !== 429
         ) {
           throw error;
         }

--- a/packages/lettermint/src/http-client.ts
+++ b/packages/lettermint/src/http-client.ts
@@ -188,12 +188,7 @@ export class LettermintHttpClient {
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
-        if (
-          error instanceof LettermintApiError &&
-          error.statusCode >= 400 &&
-          error.statusCode < 500 &&
-          error.statusCode !== 429
-        ) {
+        if (error instanceof LettermintApiError && !isRetryable(error)) {
           throw error;
         }
 
@@ -209,7 +204,7 @@ export class LettermintHttpClient {
           throw lastError;
         }
 
-        await sleep(Math.min(1000 * Math.pow(2, attempt), 10000), signal);
+        await sleep(calculateRetryDelay(attempt), signal);
       }
     }
 
@@ -265,6 +260,17 @@ export class LettermintHttpClient {
       }
     }
   }
+}
+
+function isRetryable(error: LettermintApiError): boolean {
+  if (error.statusCode === 408 || error.statusCode === 429) return true;
+  if (error.statusCode >= 500) return true;
+  return error.statusCode < 400;
+}
+
+function calculateRetryDelay(attempt: number): number {
+  const baseDelay = Math.min(1000 * Math.pow(2, attempt), 10000);
+  return Math.round(baseDelay / 2 + Math.random() * (baseDelay / 2));
 }
 
 function parseErrorMessage(text: string, statusCode: number): string {

--- a/packages/lettermint/src/http-client.ts
+++ b/packages/lettermint/src/http-client.ts
@@ -293,30 +293,26 @@ function combineSignals(
     return timeoutSignal;
   }
 
-  if (typeof AbortSignal.any === "function") {
-    return AbortSignal.any([timeoutSignal, externalSignal]);
-  }
-
-  const controller = new AbortController();
-  const abort = () => controller.abort();
-
-  timeoutSignal.addEventListener("abort", abort, { once: true });
-  externalSignal.addEventListener("abort", abort, { once: true });
-
-  if (timeoutSignal.aborted || externalSignal.aborted) {
-    controller.abort();
-  }
-
-  return controller.signal;
+  return AbortSignal.any([timeoutSignal, externalSignal]);
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(resolve, ms);
+    if (signal?.aborted) {
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+      return;
+    }
+
     const onAbort = () => {
       clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", onAbort);
       reject(new DOMException("The operation was aborted.", "AbortError"));
     };
+
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
 
     if (signal?.aborted) {
       onAbort();

--- a/packages/lettermint/src/http-client.ts
+++ b/packages/lettermint/src/http-client.ts
@@ -246,7 +246,7 @@ export class LettermintHttpClient {
         method: "POST",
         headers,
         body: JSON.stringify(body),
-        signal: requestSignal,
+        signal: requestSignal.signal,
       });
     } catch (error) {
       if (
@@ -259,6 +259,7 @@ export class LettermintHttpClient {
       }
       throw error;
     } finally {
+      requestSignal.cleanup();
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
       }
@@ -285,15 +286,43 @@ function parseErrorMessage(text: string, statusCode: number): string {
   return text || `HTTP ${statusCode}`;
 }
 
+interface CombinedSignal {
+  readonly signal: AbortSignal;
+  cleanup(): void;
+}
+
 function combineSignals(
   timeoutSignal: AbortSignal,
   externalSignal?: AbortSignal,
-): AbortSignal {
+): CombinedSignal {
   if (externalSignal == null) {
-    return timeoutSignal;
+    return { signal: timeoutSignal, cleanup: () => {} };
   }
 
-  return AbortSignal.any([timeoutSignal, externalSignal]);
+  if (typeof AbortSignal.any === "function") {
+    return {
+      signal: AbortSignal.any([timeoutSignal, externalSignal]),
+      cleanup: () => {},
+    };
+  }
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+
+  timeoutSignal.addEventListener("abort", abort, { once: true });
+  externalSignal.addEventListener("abort", abort, { once: true });
+
+  if (timeoutSignal.aborted || externalSignal.aborted) {
+    controller.abort();
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      timeoutSignal.removeEventListener("abort", abort);
+      externalSignal.removeEventListener("abort", abort);
+    },
+  };
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/lettermint/src/http-client.ts
+++ b/packages/lettermint/src/http-client.ts
@@ -1,0 +1,327 @@
+import type { ResolvedLettermintConfig } from "./config.ts";
+import type { LettermintEmail } from "./message-converter.ts";
+
+/**
+ * Lettermint message status values.
+ *
+ * @since 0.5.0
+ */
+export type LettermintStatus =
+  | "pending"
+  | "queued"
+  | "suppressed"
+  | "processed"
+  | "delivered"
+  | "opened"
+  | "clicked"
+  | "soft_bounced"
+  | "hard_bounced"
+  | "spam_complaint"
+  | "failed"
+  | "blocked"
+  | "policy_rejected"
+  | "unsubscribed";
+
+/**
+ * Response from Lettermint API for sending a single message.
+ *
+ * @since 0.5.0
+ */
+export interface LettermintResponse {
+  /** The message ID returned by Lettermint. */
+  readonly message_id: string;
+  /** Current message status. */
+  readonly status: LettermintStatus;
+}
+
+/**
+ * Response from Lettermint API for sending batch messages.
+ *
+ * @since 0.5.0
+ */
+export type LettermintBatchResponse = readonly LettermintResponse[];
+
+/**
+ * Error response from Lettermint API.
+ *
+ * @since 0.5.0
+ */
+export interface LettermintError {
+  /** Error message from Lettermint. */
+  readonly message?: string;
+  /** Error detail from Lettermint. */
+  readonly error?: string;
+  /** Validation errors from Lettermint. */
+  readonly errors?: readonly unknown[];
+}
+
+/**
+ * Lettermint API error class for API-specific failures.
+ *
+ * @since 0.5.0
+ */
+export class LettermintApiError extends Error {
+  readonly statusCode: number;
+
+  /**
+   * Creates a Lettermint API error.
+   *
+   * @param message Error message.
+   * @param statusCode HTTP status code.
+   */
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "LettermintApiError";
+    this.statusCode = statusCode;
+  }
+}
+
+/**
+ * Lettermint request timeout error.
+ *
+ * @since 0.5.0
+ */
+export class LettermintTimeoutError extends Error {
+  readonly timeout: number;
+
+  /**
+   * Creates a Lettermint request timeout error.
+   *
+   * @param timeout Request timeout in milliseconds.
+   */
+  constructor(timeout: number) {
+    super(`Lettermint API request timed out after ${timeout} ms.`);
+    this.name = "LettermintTimeoutError";
+    this.timeout = timeout;
+  }
+}
+
+/**
+ * HTTP client wrapper for Lettermint API requests.
+ *
+ * @since 0.5.0
+ */
+export class LettermintHttpClient {
+  private config: ResolvedLettermintConfig;
+
+  /**
+   * Creates a new Lettermint HTTP client.
+   *
+   * @param config Resolved Lettermint configuration.
+   */
+  constructor(config: ResolvedLettermintConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Sends a single message via Lettermint API.
+   *
+   * @param messageData The JSON data to send to Lettermint.
+   * @param signal Optional AbortSignal for cancellation.
+   * @param idempotencyKey Optional idempotency key for request deduplication.
+   * @returns Promise that resolves to the Lettermint response.
+   */
+  sendMessage(
+    messageData: LettermintEmail,
+    signal?: AbortSignal,
+    idempotencyKey?: string,
+  ): Promise<LettermintResponse> {
+    const url = `${this.config.baseUrl}/v1/send`;
+    return this.makeRequest(url, messageData, signal, idempotencyKey);
+  }
+
+  /**
+   * Sends multiple messages via Lettermint batch API.
+   *
+   * @param messagesData The messages to send to Lettermint.
+   * @param signal Optional AbortSignal for cancellation.
+   * @param idempotencyKey Optional idempotency key for request deduplication.
+   * @returns Promise that resolves to the Lettermint batch response.
+   */
+  sendBatch(
+    messagesData: readonly LettermintEmail[],
+    signal?: AbortSignal,
+    idempotencyKey?: string,
+  ): Promise<LettermintBatchResponse> {
+    const url = `${this.config.baseUrl}/v1/send/batch`;
+    return this.makeRequest(url, messagesData, signal, idempotencyKey);
+  }
+
+  private async makeRequest<
+    T extends LettermintResponse | LettermintBatchResponse,
+  >(
+    url: string,
+    body: LettermintEmail | readonly LettermintEmail[],
+    signal?: AbortSignal,
+    idempotencyKey?: string,
+  ): Promise<T> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= this.config.retries; attempt++) {
+      signal?.throwIfAborted();
+
+      try {
+        const response = await this.fetchWithAuth(
+          url,
+          body,
+          signal,
+          idempotencyKey,
+        );
+        const text = await response.text();
+
+        if (!response.ok) {
+          throw new LettermintApiError(
+            parseErrorMessage(text, response.status),
+            response.status,
+          );
+        }
+
+        try {
+          return JSON.parse(text) as T;
+        } catch (error) {
+          throw new SyntaxError(
+            `Invalid JSON response from Lettermint API: ${
+              error instanceof Error ? error.message : String(error)
+            }.`,
+          );
+        }
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        if (
+          error instanceof LettermintApiError &&
+          error.statusCode >= 400 &&
+          error.statusCode < 500
+        ) {
+          throw error;
+        }
+
+        if (
+          error instanceof Error &&
+          error.name === "AbortError" &&
+          signal?.aborted
+        ) {
+          throw error;
+        }
+
+        if (attempt === this.config.retries) {
+          throw lastError;
+        }
+
+        await sleep(Math.min(1000 * Math.pow(2, attempt), 10000), signal);
+      }
+    }
+
+    throw lastError ?? new Error("Request failed after all retry attempts.");
+  }
+
+  private async fetchWithAuth(
+    url: string,
+    body: LettermintEmail | readonly LettermintEmail[],
+    signal?: AbortSignal,
+    idempotencyKey?: string,
+  ): Promise<Response> {
+    const headers = new Headers({
+      "Content-Type": "application/json",
+      "x-lettermint-token": this.config.apiToken,
+    });
+
+    if (idempotencyKey) {
+      headers.set("Idempotency-Key", idempotencyKey);
+    }
+
+    for (const [key, value] of Object.entries(this.config.headers)) {
+      headers.set(key, value);
+    }
+
+    const timeoutController = new AbortController();
+    const timeoutId = this.config.timeout > 0
+      ? setTimeout(() => timeoutController.abort(), this.config.timeout)
+      : undefined;
+    const requestSignal = combineSignals(timeoutController.signal, signal);
+
+    try {
+      return await globalThis.fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: requestSignal,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === "AbortError" &&
+        timeoutController.signal.aborted &&
+        !signal?.aborted
+      ) {
+        throw new LettermintTimeoutError(this.config.timeout);
+      }
+      throw error;
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+}
+
+function parseErrorMessage(text: string, statusCode: number): string {
+  try {
+    const errorBody = JSON.parse(text) as LettermintError;
+    if (typeof errorBody.message === "string" && errorBody.message !== "") {
+      return errorBody.message;
+    }
+    if (typeof errorBody.error === "string" && errorBody.error !== "") {
+      return errorBody.error;
+    }
+    if (Array.isArray(errorBody.errors) && errorBody.errors.length > 0) {
+      return JSON.stringify(errorBody.errors);
+    }
+  } catch {
+    // Ignore if JSON parsing fails, as the body may be non-JSON.
+  }
+
+  return text || `HTTP ${statusCode}`;
+}
+
+function combineSignals(
+  timeoutSignal: AbortSignal,
+  externalSignal?: AbortSignal,
+): AbortSignal {
+  if (externalSignal == null) {
+    return timeoutSignal;
+  }
+
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any([timeoutSignal, externalSignal]);
+  }
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+
+  timeoutSignal.addEventListener("abort", abort, { once: true });
+  externalSignal.addEventListener("abort", abort, { once: true });
+
+  if (timeoutSignal.aborted || externalSignal.aborted) {
+    controller.abort();
+  }
+
+  return controller.signal;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    };
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/lettermint/src/http-client.ts
+++ b/packages/lettermint/src/http-client.ts
@@ -263,9 +263,8 @@ export class LettermintHttpClient {
 }
 
 function isRetryable(error: LettermintApiError): boolean {
-  if (error.statusCode === 408 || error.statusCode === 429) return true;
-  if (error.statusCode >= 500) return true;
-  return error.statusCode < 400;
+  return error.statusCode === 408 || error.statusCode === 429 ||
+    error.statusCode >= 500;
 }
 
 function calculateRetryDelay(attempt: number): number {

--- a/packages/lettermint/src/index.ts
+++ b/packages/lettermint/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Lettermint transport for Upyo email library.
+ *
+ * This module provides a transport implementation for sending emails through
+ * Lettermint's HTTP API.  It supports single messages, batch sending,
+ * attachments, provider-specific defaults, retry logic, and idempotency.
+ *
+ * @since 0.5.0
+ */
+
+export { LettermintTransport } from "./lettermint-transport.ts";
+export {
+  createLettermintConfig,
+  type LettermintConfig,
+  type LettermintSettings,
+  type ResolvedLettermintConfig,
+} from "./config.ts";
+export { LettermintApiError, LettermintTimeoutError } from "./http-client.ts";
+export type {
+  LettermintBatchResponse,
+  LettermintError,
+  LettermintResponse,
+  LettermintStatus,
+} from "./http-client.ts";

--- a/packages/lettermint/src/lettermint-transport.e2e.test.ts
+++ b/packages/lettermint/src/lettermint-transport.e2e.test.ts
@@ -10,21 +10,41 @@ import {
 
 const describeE2E = isE2eTestingEnabled() ? describe : describe.skip;
 
-describeE2E("LettermintTransport E2E", () => {
+describeE2E("LettermintTransport E2E", { concurrency: false }, () => {
+  async function waitForRateLimit(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  function assertSuccessfulReceipt(
+    receipt: Receipt,
+  ): asserts receipt is Receipt & {
+    readonly successful: true;
+    readonly messageId: string;
+  } {
+    assert.equal(
+      receipt.successful,
+      true,
+      receipt.successful ? undefined : receipt.errorMessages.join(", "),
+    );
+    assert.ok(receipt.messageId);
+  }
+
   it("sends a simple text email", async () => {
+    await waitForRateLimit();
+
     const transport = new LettermintTransport(getTestConfig().lettermint);
     const receipt = await transport.send(createTestMessage({
       subject: "[E2E] Lettermint text email",
       content: { text: "This is a Lettermint E2E test email." },
     }));
 
-    assert.equal(receipt.successful, true);
-    if (receipt.successful) {
-      assert.ok(receipt.messageId);
-    }
+    assertSuccessfulReceipt(receipt);
+    console.log(`Sent Lettermint text email with ID: ${receipt.messageId}`);
   });
 
   it("sends an HTML email", async () => {
+    await waitForRateLimit();
+
     const transport = new LettermintTransport(getTestConfig().lettermint);
     const receipt = await transport.send(createTestMessage({
       subject: "[E2E] Lettermint HTML email",
@@ -34,13 +54,39 @@ describeE2E("LettermintTransport E2E", () => {
       },
     }));
 
-    assert.equal(receipt.successful, true);
-    if (receipt.successful) {
-      assert.ok(receipt.messageId);
-    }
+    assertSuccessfulReceipt(receipt);
+    console.log(`Sent Lettermint HTML email with ID: ${receipt.messageId}`);
+  });
+
+  it("sends an email with an attachment", async () => {
+    await waitForRateLimit();
+
+    const transport = new LettermintTransport(getTestConfig().lettermint);
+    const receipt = await transport.send(createTestMessage({
+      subject: "[E2E] Lettermint attachment email",
+      content: { text: "This Lettermint E2E test email has an attachment." },
+      attachments: [
+        {
+          filename: "lettermint-e2e.txt",
+          contentType: "text/plain",
+          content: new TextEncoder().encode(
+            "This attachment was sent by the Upyo Lettermint E2E test.",
+          ),
+          inline: false,
+          contentId: "",
+        },
+      ],
+    }));
+
+    assertSuccessfulReceipt(receipt);
+    console.log(
+      `Sent Lettermint attachment email with ID: ${receipt.messageId}`,
+    );
   });
 
   it("sends multiple emails with sendMany", async () => {
+    await waitForRateLimit();
+
     const transport = new LettermintTransport(getTestConfig().lettermint);
     const receipts: Receipt[] = [];
 
@@ -58,6 +104,15 @@ describeE2E("LettermintTransport E2E", () => {
     }
 
     assert.equal(receipts.length, 2);
-    assert.ok(receipts.every((receipt) => receipt.successful));
+    for (const receipt of receipts) {
+      assertSuccessfulReceipt(receipt);
+    }
+    console.log(
+      `Sent Lettermint batch emails with IDs: ${
+        receipts.map((receipt) =>
+          receipt.successful ? receipt.messageId : "failed"
+        ).join(", ")
+      }`,
+    );
   });
 });

--- a/packages/lettermint/src/lettermint-transport.e2e.test.ts
+++ b/packages/lettermint/src/lettermint-transport.e2e.test.ts
@@ -1,0 +1,63 @@
+import type { Receipt } from "@upyo/core";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { LettermintTransport } from "./lettermint-transport.ts";
+import {
+  createTestMessage,
+  getTestConfig,
+  isE2eTestingEnabled,
+} from "./test-utils/test-config.ts";
+
+const describeE2E = isE2eTestingEnabled() ? describe : describe.skip;
+
+describeE2E("LettermintTransport E2E", () => {
+  it("sends a simple text email", async () => {
+    const transport = new LettermintTransport(getTestConfig().lettermint);
+    const receipt = await transport.send(createTestMessage({
+      subject: "[E2E] Lettermint text email",
+      content: { text: "This is a Lettermint E2E test email." },
+    }));
+
+    assert.equal(receipt.successful, true);
+    if (receipt.successful) {
+      assert.ok(receipt.messageId);
+    }
+  });
+
+  it("sends an HTML email", async () => {
+    const transport = new LettermintTransport(getTestConfig().lettermint);
+    const receipt = await transport.send(createTestMessage({
+      subject: "[E2E] Lettermint HTML email",
+      content: {
+        html: "<h1>Hello from Upyo</h1><p>This is a Lettermint test.</p>",
+        text: "Hello from Upyo\n\nThis is a Lettermint test.",
+      },
+    }));
+
+    assert.equal(receipt.successful, true);
+    if (receipt.successful) {
+      assert.ok(receipt.messageId);
+    }
+  });
+
+  it("sends multiple emails with sendMany", async () => {
+    const transport = new LettermintTransport(getTestConfig().lettermint);
+    const receipts: Receipt[] = [];
+
+    for await (
+      const receipt of transport.sendMany([
+        createTestMessage({
+          subject: "[E2E] Lettermint batch email 1",
+        }),
+        createTestMessage({
+          subject: "[E2E] Lettermint batch email 2",
+        }),
+      ])
+    ) {
+      receipts.push(receipt);
+    }
+
+    assert.equal(receipts.length, 2);
+    assert.ok(receipts.every((receipt) => receipt.successful));
+  });
+});

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -209,6 +209,43 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
       },
     );
   });
+
+  it("retries 429 rate limit responses", async () => {
+    let calls = 0;
+
+    await withMockedFetch(
+      () => {
+        calls++;
+        if (calls === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ message: "Too many requests" }),
+              { status: 429, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_rate_limit", status: "pending" }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          retries: 1,
+        });
+        const receipt = await transport.send(createMessage());
+
+        assert.equal(calls, 2);
+        assert.equal(receipt.successful, true);
+        if (receipt.successful) {
+          assert.equal(receipt.messageId, "msg_rate_limit");
+        }
+      },
+    );
+  });
 });
 
 describe("LettermintTransport - sendMany", { concurrency: false }, () => {

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -171,6 +171,30 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
     );
   });
 
+  it("generates an idempotency key when the provided key is empty", async () => {
+    let capturedHeaders = new Headers();
+
+    await withMockedFetch(
+      (_url, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_123", status: "pending" }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({ apiToken: "test-token" });
+        await transport.send(createMessage({ idempotencyKey: "" }));
+
+        const idempotencyKey = capturedHeaders.get("Idempotency-Key");
+        assert.ok(idempotencyKey);
+        assert.notEqual(idempotencyKey, "");
+      },
+    );
+  });
+
   it("retries request timeouts from the transport config", async () => {
     let calls = 0;
 
@@ -450,6 +474,42 @@ describe("LettermintTransport - sendMany", { concurrency: false }, () => {
           assert.equal(receipts[0].messageId, "msg_1");
           assert.equal(receipts[1].messageId, "msg_2");
         }
+      },
+    );
+  });
+
+  it("generates a batch idempotency key when the first key is empty", async () => {
+    let capturedHeaders = new Headers();
+
+    await withMockedFetch(
+      (_url, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              { message_id: "msg_1", status: "pending" },
+              { message_id: "msg_2", status: "pending" },
+            ]),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({ apiToken: "test-token" });
+        const receipts: Receipt[] = [];
+        for await (
+          const receipt of transport.sendMany([
+            createMessage({ idempotencyKey: "" }),
+            createMessage(),
+          ])
+        ) {
+          receipts.push(receipt);
+        }
+
+        const idempotencyKey = capturedHeaders.get("Idempotency-Key");
+        assert.ok(idempotencyKey);
+        assert.notEqual(idempotencyKey, "");
+        assert.ok(receipts.every((receipt) => receipt.successful));
       },
     );
   });

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -1,0 +1,416 @@
+import type { Message, Receipt } from "@upyo/core";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { LettermintTransport } from "./lettermint-transport.ts";
+
+function createMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    sender: { address: "sender@example.com" },
+    recipients: [{ address: "recipient@example.com" }],
+    ccRecipients: [],
+    bccRecipients: [],
+    replyRecipients: [],
+    subject: "Test Subject",
+    content: { text: "Test content" },
+    attachments: [],
+    priority: "normal",
+    tags: [],
+    headers: new Headers(),
+    ...overrides,
+  };
+}
+
+let fetchMockChain = Promise.resolve();
+
+async function withMockedFetch<T>(
+  fetchMock: typeof globalThis.fetch,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const previous = fetchMockChain;
+  let release: () => void = () => {};
+  fetchMockChain = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = fetchMock;
+    return await callback();
+  } finally {
+    globalThis.fetch = originalFetch;
+    release();
+  }
+}
+
+describe("LettermintTransport - config", { concurrency: false }, () => {
+  it("creates a transport with minimal config", () => {
+    const transport = new LettermintTransport({
+      apiToken: "test-token",
+    });
+
+    assert.equal(transport.config.apiToken, "test-token");
+    assert.equal(transport.config.baseUrl, "https://api.lettermint.co");
+    assert.equal(transport.config.timeout, 30000);
+    assert.equal(transport.config.retries, 3);
+  });
+
+  it("creates a transport with custom config", () => {
+    const transport = new LettermintTransport({
+      apiToken: "test-token",
+      baseUrl: "https://lettermint.example.com",
+      timeout: 10000,
+      retries: 1,
+      route: "transactional",
+      tag: "welcome",
+    });
+
+    assert.equal(transport.config.baseUrl, "https://lettermint.example.com");
+    assert.equal(transport.config.timeout, 10000);
+    assert.equal(transport.config.retries, 1);
+    assert.equal(transport.config.route, "transactional");
+    assert.equal(transport.config.tag, "welcome");
+  });
+});
+
+describe("LettermintTransport - send", { concurrency: false }, () => {
+  it("sends a message successfully", async () => {
+    let capturedUrl = "";
+    let capturedBody: unknown;
+    let capturedHeaders = new Headers();
+
+    await withMockedFetch(
+      (url, init) => {
+        capturedUrl = String(url);
+        capturedBody = JSON.parse(String(init?.body));
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_123", status: "pending" }),
+            {
+              status: 202,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          baseUrl: "https://api.example.com",
+        });
+        const receipt = await transport.send(createMessage({
+          idempotencyKey: "idem-123",
+        }));
+
+        assert.equal(capturedUrl, "https://api.example.com/v1/send");
+        assert.equal(capturedHeaders.get("x-lettermint-token"), "test-token");
+        assert.equal(capturedHeaders.get("Idempotency-Key"), "idem-123");
+        assert.deepEqual(capturedBody, {
+          from: "sender@example.com",
+          to: ["recipient@example.com"],
+          subject: "Test Subject",
+          text: "Test content",
+        });
+        assert.equal(receipt.successful, true);
+        if (receipt.successful) {
+          assert.equal(receipt.messageId, "msg_123");
+        }
+      },
+    );
+  });
+
+  it("returns failure receipts for API errors", async () => {
+    await withMockedFetch(
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ message: "Invalid API token" }),
+            {
+              status: 401,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ),
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "bad-token",
+          retries: 0,
+        });
+        const receipt = await transport.send(createMessage());
+
+        assert.equal(receipt.successful, false);
+        if (!receipt.successful) {
+          assert.deepEqual(receipt.errorMessages, ["Invalid API token"]);
+        }
+      },
+    );
+  });
+
+  it("generates an idempotency key when not provided", async () => {
+    let capturedHeaders = new Headers();
+
+    await withMockedFetch(
+      (_url, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_123", status: "pending" }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({ apiToken: "test-token" });
+        await transport.send(createMessage());
+
+        const idempotencyKey = capturedHeaders.get("Idempotency-Key");
+        assert.ok(idempotencyKey);
+        assert.ok(idempotencyKey.length > 10);
+      },
+    );
+  });
+
+  it("retries request timeouts from the transport config", async () => {
+    let calls = 0;
+
+    await withMockedFetch(
+      (_url, init) => {
+        calls++;
+        if (calls === 1) {
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            }, { once: true });
+          });
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_retry", status: "pending" }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          timeout: 1,
+          retries: 1,
+        });
+        const receipt = await transport.send(createMessage());
+
+        assert.equal(calls, 2);
+        assert.equal(receipt.successful, true);
+        if (receipt.successful) {
+          assert.equal(receipt.messageId, "msg_retry");
+        }
+      },
+    );
+  });
+});
+
+describe("LettermintTransport - sendMany", { concurrency: false }, () => {
+  it("uses the batch API for multiple messages", async () => {
+    let capturedUrl = "";
+    let capturedBody: unknown;
+    let capturedHeaders = new Headers();
+
+    await withMockedFetch(
+      (url, init) => {
+        capturedUrl = String(url);
+        capturedBody = JSON.parse(String(init?.body));
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              { message_id: "msg_1", status: "pending" },
+              { message_id: "msg_2", status: "queued" },
+            ]),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          baseUrl: "https://api.example.com",
+        });
+        const messages = [
+          createMessage({
+            recipients: [{ address: "one@example.com" }],
+            idempotencyKey: "batch-key",
+          }),
+          createMessage({
+            recipients: [{ address: "two@example.com" }],
+          }),
+        ];
+
+        const receipts: Receipt[] = [];
+        for await (const receipt of transport.sendMany(messages)) {
+          receipts.push(receipt);
+        }
+
+        assert.equal(capturedUrl, "https://api.example.com/v1/send/batch");
+        assert.equal(capturedHeaders.get("Idempotency-Key"), "batch-key");
+        assert.deepEqual(capturedBody, [
+          {
+            from: "sender@example.com",
+            to: ["one@example.com"],
+            subject: "Test Subject",
+            text: "Test content",
+          },
+          {
+            from: "sender@example.com",
+            to: ["two@example.com"],
+            subject: "Test Subject",
+            text: "Test content",
+          },
+        ]);
+        assert.equal(receipts.length, 2);
+        assert.equal(receipts[0].successful, true);
+        assert.equal(receipts[1].successful, true);
+        if (receipts[0].successful && receipts[1].successful) {
+          assert.equal(receipts[0].messageId, "msg_1");
+          assert.equal(receipts[1].messageId, "msg_2");
+        }
+      },
+    );
+  });
+
+  it("chunks batches over 500 messages", async () => {
+    const bodySizes: number[] = [];
+
+    await withMockedFetch(
+      (_url, init) => {
+        const body = JSON.parse(String(init?.body)) as unknown[];
+        bodySizes.push(body.length);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              body.map((_, index) => ({
+                message_id: `msg_${bodySizes.length}_${index}`,
+                status: "pending",
+              })),
+            ),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({ apiToken: "test-token" });
+        const messages = Array.from(
+          { length: 501 },
+          (_, index) =>
+            createMessage({
+              recipients: [{ address: `user${index}@example.com` }],
+            }),
+        );
+
+        const receipts: Receipt[] = [];
+        for await (const receipt of transport.sendMany(messages)) {
+          receipts.push(receipt);
+        }
+
+        assert.deepEqual(bodySizes, [500, 1]);
+        assert.equal(receipts.length, 501);
+        assert.ok(receipts.every((receipt) => receipt.successful));
+      },
+    );
+  });
+
+  it("streams async batches as each chunk fills", async () => {
+    const bodySizes: number[] = [];
+    let generated = 0;
+
+    async function* messages(): AsyncIterable<Message> {
+      for (let index = 0; index < 501; index++) {
+        generated++;
+        yield createMessage({
+          recipients: [{ address: `user${index}@example.com` }],
+        });
+      }
+    }
+
+    await withMockedFetch(
+      (_url, init) => {
+        const body = JSON.parse(String(init?.body)) as unknown[];
+        bodySizes.push(body.length);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              body.map((_, index) => ({
+                message_id: `msg_${bodySizes.length}_${index}`,
+                status: "pending",
+              })),
+            ),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({ apiToken: "test-token" });
+        const receipts: Receipt[] = [];
+        for await (const receipt of transport.sendMany(messages())) {
+          receipts.push(receipt);
+          if (receipts.length === 500) break;
+        }
+
+        assert.deepEqual(bodySizes, [500]);
+        assert.equal(generated, 500);
+        assert.equal(receipts.length, 500);
+        assert.ok(receipts.every((receipt) => receipt.successful));
+      },
+    );
+  });
+
+  it("returns no receipts for empty input", async () => {
+    const transport = new LettermintTransport({ apiToken: "test-token" });
+    const receipts: Receipt[] = [];
+
+    for await (const receipt of transport.sendMany([])) {
+      receipts.push(receipt);
+    }
+
+    assert.equal(receipts.length, 0);
+  });
+
+  it("returns one failed receipt per message when a batch fails", async () => {
+    await withMockedFetch(
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ message: "Batch rejected" }),
+            {
+              status: 422,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ),
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          retries: 0,
+        });
+        const receipts: Receipt[] = [];
+        for await (
+          const receipt of transport.sendMany([
+            createMessage(),
+            createMessage(),
+          ])
+        ) {
+          receipts.push(receipt);
+        }
+
+        assert.equal(receipts.length, 2);
+        assert.ok(receipts.every((receipt) => !receipt.successful));
+        for (const receipt of receipts) {
+          if (!receipt.successful) {
+            assert.deepEqual(receipt.errorMessages, ["Batch rejected"]);
+          }
+        }
+      },
+    );
+  });
+});

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -348,6 +348,35 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
     );
   });
 
+  it("does not retry redirection responses", async () => {
+    let calls = 0;
+
+    await withMockedFetch(
+      () => {
+        calls++;
+        return Promise.resolve(
+          new Response("", {
+            status: 302,
+            headers: { Location: "https://api.example.com/other" },
+          }),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          retries: 1,
+        });
+        const receipt = await transport.send(createMessage());
+
+        assert.equal(calls, 1);
+        assert.equal(receipt.successful, false);
+        if (!receipt.successful) {
+          assert.deepEqual(receipt.errorMessages, ["HTTP 302"]);
+        }
+      },
+    );
+  });
+
   it("removes abort listeners after retry backoff completes", async () => {
     let calls = 0;
     let addedAbortListeners = 0;
@@ -516,7 +545,6 @@ describe("LettermintTransport - sendMany", { concurrency: false }, () => {
         const messages = [
           createMessage({
             recipients: [{ address: "one@example.com" }],
-            idempotencyKey: "batch-key",
           }),
           createMessage({
             recipients: [{ address: "two@example.com" }],
@@ -529,7 +557,7 @@ describe("LettermintTransport - sendMany", { concurrency: false }, () => {
         }
 
         assert.equal(capturedUrl, "https://api.example.com/v1/send/batch");
-        assert.equal(capturedHeaders.get("Idempotency-Key"), "batch-key");
+        assert.ok(capturedHeaders.get("Idempotency-Key"));
         assert.deepEqual(capturedBody, [
           {
             from: "sender@example.com",
@@ -551,6 +579,75 @@ describe("LettermintTransport - sendMany", { concurrency: false }, () => {
           assert.equal(receipts[0].messageId, "msg_1");
           assert.equal(receipts[1].messageId, "msg_2");
         }
+      },
+    );
+  });
+
+  it("uses per-message idempotency keys outside the batch API", async () => {
+    const capturedUrls: string[] = [];
+    const capturedHeaders: Headers[] = [];
+    const capturedBodies: unknown[] = [];
+
+    await withMockedFetch(
+      (url, init) => {
+        capturedUrls.push(String(url));
+        capturedHeaders.push(new Headers(init?.headers));
+        capturedBodies.push(JSON.parse(String(init?.body)));
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              message_id: `msg_${capturedUrls.length}`,
+              status: "pending",
+            }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          baseUrl: "https://api.example.com",
+        });
+        const receipts: Receipt[] = [];
+        for await (
+          const receipt of transport.sendMany([
+            createMessage({
+              recipients: [{ address: "one@example.com" }],
+              idempotencyKey: "key-1",
+            }),
+            createMessage({
+              recipients: [{ address: "two@example.com" }],
+              idempotencyKey: "key-2",
+            }),
+          ])
+        ) {
+          receipts.push(receipt);
+        }
+
+        assert.deepEqual(capturedUrls, [
+          "https://api.example.com/v1/send",
+          "https://api.example.com/v1/send",
+        ]);
+        assert.deepEqual(
+          capturedHeaders.map((headers) => headers.get("Idempotency-Key")),
+          ["key-1", "key-2"],
+        );
+        assert.deepEqual(capturedBodies, [
+          {
+            from: "sender@example.com",
+            to: ["one@example.com"],
+            subject: "Test Subject",
+            text: "Test content",
+          },
+          {
+            from: "sender@example.com",
+            to: ["two@example.com"],
+            subject: "Test Subject",
+            text: "Test content",
+          },
+        ]);
+        assert.equal(receipts.length, 2);
+        assert.ok(receipts.every((receipt) => receipt.successful));
       },
     );
   });

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -175,6 +175,18 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
     );
   });
 
+  it("propagates AbortError for aborted sends", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const transport = new LettermintTransport({ apiToken: "test-token" });
+
+    await assert.rejects(
+      () => transport.send(createMessage(), { signal: controller.signal }),
+      { name: "AbortError" },
+    );
+  });
+
   it("generates an idempotency key when not provided", async () => {
     let capturedHeaders = new Headers();
 
@@ -294,6 +306,43 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
         assert.equal(receipt.successful, true);
         if (receipt.successful) {
           assert.equal(receipt.messageId, "msg_rate_limit");
+        }
+      },
+    );
+  });
+
+  it("retries 408 timeout responses", async () => {
+    let calls = 0;
+
+    await withMockedFetch(
+      () => {
+        calls++;
+        if (calls === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ message: "Request timeout" }),
+              { status: 408, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_timeout", status: "pending" }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          retries: 1,
+        });
+        const receipt = await transport.send(createMessage());
+
+        assert.equal(calls, 2);
+        assert.equal(receipt.successful, true);
+        if (receipt.successful) {
+          assert.equal(receipt.messageId, "msg_timeout");
         }
       },
     );
@@ -746,6 +795,53 @@ describe("LettermintTransport - sendMany", { concurrency: false }, () => {
           assert.deepEqual(receipts[2].errorMessages, [
             'Lettermint reported message status "failed".',
           ]);
+        }
+      },
+    );
+  });
+
+  it("preserves local batch failures when the request fails", async () => {
+    await withMockedFetch(
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ message: "Batch rejected" }),
+            {
+              status: 422,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ),
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          retries: 0,
+        });
+        const receipts: Receipt[] = [];
+        for await (
+          const receipt of transport.sendMany([
+            createMessage({ recipients: [{ address: "one@example.com" }] }),
+            createMessage({
+              recipients: [{ address: "bad@example.com" }],
+              tags: ["one", "two"],
+            }),
+            createMessage({ recipients: [{ address: "two@example.com" }] }),
+          ])
+        ) {
+          receipts.push(receipt);
+        }
+
+        assert.equal(receipts.length, 3);
+        assert.ok(receipts.every((receipt) => !receipt.successful));
+        if (
+          !receipts[0].successful && !receipts[1].successful &&
+          !receipts[2].successful
+        ) {
+          assert.deepEqual(receipts[0].errorMessages, ["Batch rejected"]);
+          assert.deepEqual(receipts[1].errorMessages, [
+            "Lettermint supports at most one tag per message.",
+          ]);
+          assert.deepEqual(receipts[2].errorMessages, ["Batch rejected"]);
         }
       },
     );

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -246,6 +246,74 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
       },
     );
   });
+
+  it("removes abort listeners after retry backoff completes", async () => {
+    let calls = 0;
+    let addedAbortListeners = 0;
+    let removedAbortListeners = 0;
+    const controller = new AbortController();
+    const addEventListener = controller.signal.addEventListener.bind(
+      controller.signal,
+    );
+    const removeEventListener = controller.signal.removeEventListener.bind(
+      controller.signal,
+    );
+
+    Object.defineProperty(controller.signal, "addEventListener", {
+      value: (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+      ) => {
+        if (type === "abort") addedAbortListeners++;
+        addEventListener(type, listener, options);
+      },
+    });
+    Object.defineProperty(controller.signal, "removeEventListener", {
+      value: (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+      ) => {
+        if (type === "abort") removedAbortListeners++;
+        removeEventListener(type, listener, options);
+      },
+    });
+
+    await withMockedFetch(
+      () => {
+        calls++;
+        if (calls === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ message: "Too many requests" }),
+              { status: 429, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_rate_limit", status: "pending" }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+          retries: 1,
+        });
+        const receipt = await transport.send(
+          createMessage(),
+          { signal: controller.signal },
+        );
+
+        assert.equal(receipt.successful, true);
+        assert.ok(addedAbortListeners > 0);
+        assert.equal(removedAbortListeners, addedAbortListeners);
+      },
+    );
+  });
 });
 
 describe("LettermintTransport - sendMany", { concurrency: false }, () => {

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -147,6 +147,34 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
     );
   });
 
+  it("returns failure receipts for non-delivery statuses", async () => {
+    await withMockedFetch(
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              message_id: "msg_rejected",
+              status: "policy_rejected",
+            }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      async () => {
+        const transport = new LettermintTransport({
+          apiToken: "test-token",
+        });
+        const receipt = await transport.send(createMessage());
+
+        assert.equal(receipt.successful, false);
+        if (!receipt.successful) {
+          assert.deepEqual(receipt.errorMessages, [
+            'Lettermint reported message status "policy_rejected".',
+          ]);
+        }
+      },
+    );
+  });
+
   it("generates an idempotency key when not provided", async () => {
     let capturedHeaders = new Headers();
 
@@ -672,6 +700,51 @@ describe("LettermintTransport - sendMany", { concurrency: false }, () => {
         if (!receipts[1].successful) {
           assert.deepEqual(receipts[1].errorMessages, [
             "Lettermint supports at most one tag per message.",
+          ]);
+        }
+      },
+    );
+  });
+
+  it("returns per-message failures for batch non-delivery statuses", async () => {
+    await withMockedFetch(
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify([
+              { message_id: "msg_1", status: "queued" },
+              { message_id: "msg_2", status: "suppressed" },
+              { message_id: "msg_3", status: "failed" },
+            ]),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      async () => {
+        const transport = new LettermintTransport({ apiToken: "test-token" });
+        const receipts: Receipt[] = [];
+        for await (
+          const receipt of transport.sendMany([
+            createMessage({ recipients: [{ address: "one@example.com" }] }),
+            createMessage({ recipients: [{ address: "two@example.com" }] }),
+            createMessage({ recipients: [{ address: "three@example.com" }] }),
+          ])
+        ) {
+          receipts.push(receipt);
+        }
+
+        assert.equal(receipts.length, 3);
+        assert.equal(receipts[0].successful, true);
+        assert.equal(receipts[1].successful, false);
+        assert.equal(receipts[2].successful, false);
+        if (receipts[0].successful) {
+          assert.equal(receipts[0].messageId, "msg_1");
+        }
+        if (!receipts[1].successful && !receipts[2].successful) {
+          assert.deepEqual(receipts[1].errorMessages, [
+            'Lettermint reported message status "suppressed".',
+          ]);
+          assert.deepEqual(receipts[2].errorMessages, [
+            'Lettermint reported message status "failed".',
           ]);
         }
       },

--- a/packages/lettermint/src/lettermint-transport.test.ts
+++ b/packages/lettermint/src/lettermint-transport.test.ts
@@ -314,6 +314,76 @@ describe("LettermintTransport - send", { concurrency: false }, () => {
       },
     );
   });
+
+  it("falls back when AbortSignal.any is unavailable", async () => {
+    const originalAny = AbortSignal.any;
+    let addedAbortListeners = 0;
+    let removedAbortListeners = 0;
+    const controller = new AbortController();
+    const addEventListener = controller.signal.addEventListener.bind(
+      controller.signal,
+    );
+    const removeEventListener = controller.signal.removeEventListener.bind(
+      controller.signal,
+    );
+
+    Object.defineProperty(controller.signal, "addEventListener", {
+      value: (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+      ) => {
+        if (type === "abort") addedAbortListeners++;
+        addEventListener(type, listener, options);
+      },
+    });
+    Object.defineProperty(controller.signal, "removeEventListener", {
+      value: (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+      ) => {
+        if (type === "abort") removedAbortListeners++;
+        removeEventListener(type, listener, options);
+      },
+    });
+
+    await withMockedFetch(
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ message_id: "msg_fallback", status: "pending" }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      async () => {
+        Object.defineProperty(AbortSignal, "any", {
+          value: undefined,
+          configurable: true,
+          writable: true,
+        });
+        try {
+          const transport = new LettermintTransport({
+            apiToken: "test-token",
+          });
+          const receipt = await transport.send(
+            createMessage(),
+            { signal: controller.signal },
+          );
+
+          assert.equal(receipt.successful, true);
+          assert.ok(addedAbortListeners > 0);
+          assert.equal(removedAbortListeners, addedAbortListeners);
+        } finally {
+          Object.defineProperty(AbortSignal, "any", {
+            value: originalAny,
+            configurable: true,
+            writable: true,
+          });
+        }
+      },
+    );
+  });
 });
 
 describe("LettermintTransport - sendMany", { concurrency: false }, () => {
@@ -479,6 +549,73 @@ describe("LettermintTransport - sendMany", { concurrency: false }, () => {
     }
 
     assert.equal(receipts.length, 0);
+  });
+
+  it("returns per-message failures for batch conversion errors", async () => {
+    let capturedBody: unknown;
+
+    await withMockedFetch(
+      (_url, init) => {
+        capturedBody = JSON.parse(String(init?.body));
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              { message_id: "msg_1", status: "pending" },
+              { message_id: "msg_2", status: "pending" },
+            ]),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      },
+      async () => {
+        const transport = new LettermintTransport({ apiToken: "test-token" });
+        const receipts: Receipt[] = [];
+        for await (
+          const receipt of transport.sendMany([
+            createMessage({
+              recipients: [{ address: "one@example.com" }],
+            }),
+            createMessage({
+              recipients: [{ address: "bad@example.com" }],
+              tags: ["one", "two"],
+            }),
+            createMessage({
+              recipients: [{ address: "two@example.com" }],
+            }),
+          ])
+        ) {
+          receipts.push(receipt);
+        }
+
+        assert.deepEqual(capturedBody, [
+          {
+            from: "sender@example.com",
+            to: ["one@example.com"],
+            subject: "Test Subject",
+            text: "Test content",
+          },
+          {
+            from: "sender@example.com",
+            to: ["two@example.com"],
+            subject: "Test Subject",
+            text: "Test content",
+          },
+        ]);
+        assert.equal(receipts.length, 3);
+        assert.equal(receipts[0].successful, true);
+        assert.equal(receipts[1].successful, false);
+        assert.equal(receipts[2].successful, true);
+        if (receipts[0].successful && receipts[2].successful) {
+          assert.equal(receipts[0].messageId, "msg_1");
+          assert.equal(receipts[2].messageId, "msg_2");
+        }
+        if (!receipts[1].successful) {
+          assert.deepEqual(receipts[1].errorMessages, [
+            "Lettermint supports at most one tag per message.",
+          ]);
+        }
+      },
+    );
   });
 
   it("returns one failed receipt per message when a batch fails", async () => {

--- a/packages/lettermint/src/lettermint-transport.ts
+++ b/packages/lettermint/src/lettermint-transport.ts
@@ -62,7 +62,7 @@ export class LettermintTransport implements Transport {
       options?.signal?.throwIfAborted();
 
       const emailData = await convertMessage(message, this.config);
-      const idempotencyKey = message.idempotencyKey ?? generateIdempotencyKey();
+      const idempotencyKey = normalizeIdempotencyKey(message.idempotencyKey);
 
       options?.signal?.throwIfAborted();
 
@@ -118,8 +118,9 @@ export class LettermintTransport implements Transport {
     if (messages.length === 0) return;
 
     try {
-      const idempotencyKey = messages[0]?.idempotencyKey ??
-        generateIdempotencyKey();
+      const idempotencyKey = normalizeIdempotencyKey(
+        messages[0]?.idempotencyKey,
+      );
       const batchData: LettermintEmail[] = [];
       const receipts: (Receipt | undefined)[] = [];
 
@@ -189,4 +190,10 @@ export class LettermintTransport implements Transport {
       }
     }
   }
+}
+
+function normalizeIdempotencyKey(idempotencyKey: string | undefined): string {
+  return idempotencyKey != null && idempotencyKey !== ""
+    ? idempotencyKey
+    : generateIdempotencyKey();
 }

--- a/packages/lettermint/src/lettermint-transport.ts
+++ b/packages/lettermint/src/lettermint-transport.ts
@@ -78,6 +78,7 @@ export class LettermintTransport implements Transport {
 
       return responseToReceipt(response);
     } catch (error) {
+      if (isAbortError(error)) throw error;
       return {
         successful: false,
         errorMessages: [error instanceof Error ? error.message : String(error)],
@@ -118,34 +119,34 @@ export class LettermintTransport implements Transport {
   ): AsyncIterable<Receipt> {
     if (messages.length === 0) return;
 
+    const idempotencyKey = normalizeIdempotencyKey(
+      messages[0]?.idempotencyKey,
+    );
+    const batchData: LettermintEmail[] = [];
+    const receipts: (Receipt | undefined)[] = [];
+
+    for (const message of messages) {
+      try {
+        batchData.push(await convertMessage(message, this.config));
+        receipts.push(undefined);
+      } catch (error) {
+        receipts.push({
+          successful: false,
+          errorMessages: [
+            error instanceof Error ? error.message : String(error),
+          ],
+        });
+      }
+    }
+
+    if (batchData.length === 0) {
+      for (const receipt of receipts) {
+        if (receipt !== undefined) yield receipt;
+      }
+      return;
+    }
+
     try {
-      const idempotencyKey = normalizeIdempotencyKey(
-        messages[0]?.idempotencyKey,
-      );
-      const batchData: LettermintEmail[] = [];
-      const receipts: (Receipt | undefined)[] = [];
-
-      for (const message of messages) {
-        try {
-          batchData.push(await convertMessage(message, this.config));
-          receipts.push(undefined);
-        } catch (error) {
-          receipts.push({
-            successful: false,
-            errorMessages: [
-              error instanceof Error ? error.message : String(error),
-            ],
-          });
-        }
-      }
-
-      if (batchData.length === 0) {
-        for (const receipt of receipts) {
-          if (receipt !== undefined) yield receipt;
-        }
-        return;
-      }
-
       options?.signal?.throwIfAborted();
 
       const response = await this.httpClient.sendBatch(
@@ -166,10 +167,15 @@ export class LettermintTransport implements Transport {
         yield responseToReceipt(result);
       }
     } catch (error) {
+      if (isAbortError(error)) throw error;
       const errorMessage = error instanceof Error
         ? error.message
         : String(error);
-      for (let i = 0; i < messages.length; i++) {
+      for (const receipt of receipts) {
+        if (receipt !== undefined) {
+          yield receipt;
+          continue;
+        }
         yield {
           successful: false,
           errorMessages: [errorMessage],
@@ -227,4 +233,8 @@ function isSuccessfulStatus(status: LettermintStatus): boolean {
     case "unsubscribed":
       return false;
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }

--- a/packages/lettermint/src/lettermint-transport.ts
+++ b/packages/lettermint/src/lettermint-transport.ts
@@ -1,7 +1,11 @@
 import type { Message, Receipt, Transport, TransportOptions } from "@upyo/core";
 import type { LettermintConfig, ResolvedLettermintConfig } from "./config.ts";
 import { createLettermintConfig } from "./config.ts";
-import { LettermintHttpClient } from "./http-client.ts";
+import {
+  LettermintHttpClient,
+  type LettermintResponse,
+  type LettermintStatus,
+} from "./http-client.ts";
 import {
   convertMessage,
   generateIdempotencyKey,
@@ -72,10 +76,7 @@ export class LettermintTransport implements Transport {
         idempotencyKey,
       );
 
-      return {
-        successful: true,
-        messageId: response.message_id,
-      };
+      return responseToReceipt(response);
     } catch (error) {
       return {
         successful: false,
@@ -162,21 +163,7 @@ export class LettermintTransport implements Transport {
         }
 
         const result = response[responseIndex++];
-        let responseReceipt: Receipt;
-        if (result?.message_id) {
-          responseReceipt = {
-            successful: true,
-            messageId: result.message_id,
-          };
-        } else {
-          responseReceipt = {
-            successful: false,
-            errorMessages: [
-              "Lettermint batch response is missing a message ID.",
-            ],
-          };
-        }
-        yield responseReceipt;
+        yield responseToReceipt(result);
       }
     } catch (error) {
       const errorMessage = error instanceof Error
@@ -196,4 +183,48 @@ function normalizeIdempotencyKey(idempotencyKey: string | undefined): string {
   return idempotencyKey != null && idempotencyKey !== ""
     ? idempotencyKey
     : generateIdempotencyKey();
+}
+
+function responseToReceipt(response: LettermintResponse | undefined): Receipt {
+  if (response?.message_id == null || response.message_id === "") {
+    return {
+      successful: false,
+      errorMessages: ["Lettermint response is missing a message ID."],
+    };
+  }
+
+  if (isSuccessfulStatus(response.status)) {
+    return {
+      successful: true,
+      messageId: response.message_id,
+    };
+  }
+
+  return {
+    successful: false,
+    errorMessages: [
+      `Lettermint reported message status "${response.status}".`,
+    ],
+  };
+}
+
+function isSuccessfulStatus(status: LettermintStatus): boolean {
+  switch (status) {
+    case "pending":
+    case "queued":
+    case "processed":
+    case "delivered":
+    case "opened":
+    case "clicked":
+      return true;
+    case "suppressed":
+    case "soft_bounced":
+    case "hard_bounced":
+    case "spam_complaint":
+    case "failed":
+    case "blocked":
+    case "policy_rejected":
+    case "unsubscribed":
+      return false;
+  }
 }

--- a/packages/lettermint/src/lettermint-transport.ts
+++ b/packages/lettermint/src/lettermint-transport.ts
@@ -95,29 +95,16 @@ export class LettermintTransport implements Transport {
   ): AsyncIterable<Receipt> {
     options?.signal?.throwIfAborted();
 
-    if (Symbol.asyncIterator in messages) {
-      let chunk: Message[] = [];
-      for await (const message of messages as AsyncIterable<Message>) {
-        options?.signal?.throwIfAborted();
-        chunk.push(message);
-        if (chunk.length === MAX_BATCH_SIZE) {
-          yield* this.sendBatch(chunk, options);
-          chunk = [];
-        }
+    let chunk: Message[] = [];
+    for await (const message of messages) {
+      options?.signal?.throwIfAborted();
+      chunk.push(message);
+      if (chunk.length === MAX_BATCH_SIZE) {
+        yield* this.sendBatch(chunk, options);
+        chunk = [];
       }
-      yield* this.sendBatch(chunk, options);
-    } else {
-      let chunk: Message[] = [];
-      for (const message of messages as Iterable<Message>) {
-        options?.signal?.throwIfAborted();
-        chunk.push(message);
-        if (chunk.length === MAX_BATCH_SIZE) {
-          yield* this.sendBatch(chunk, options);
-          chunk = [];
-        }
-      }
-      yield* this.sendBatch(chunk, options);
     }
+    yield* this.sendBatch(chunk, options);
   }
 
   private async *sendBatch(

--- a/packages/lettermint/src/lettermint-transport.ts
+++ b/packages/lettermint/src/lettermint-transport.ts
@@ -1,0 +1,172 @@
+import type { Message, Receipt, Transport, TransportOptions } from "@upyo/core";
+import type { LettermintConfig, ResolvedLettermintConfig } from "./config.ts";
+import { createLettermintConfig } from "./config.ts";
+import { LettermintHttpClient } from "./http-client.ts";
+import { convertMessage, generateIdempotencyKey } from "./message-converter.ts";
+
+const MAX_BATCH_SIZE = 500;
+
+/**
+ * Lettermint transport implementation for sending emails via Lettermint API.
+ *
+ * @example
+ * ```typescript
+ * import { createMessage } from "@upyo/core";
+ * import { LettermintTransport } from "@upyo/lettermint";
+ *
+ * const transport = new LettermintTransport({
+ *   apiToken: "your-project-api-token",
+ * });
+ *
+ * const receipt = await transport.send(createMessage({
+ *   from: "sender@example.com",
+ *   to: "recipient@example.com",
+ *   subject: "Hello from Lettermint",
+ *   content: { text: "Hello!" },
+ * }));
+ * ```
+ *
+ * @since 0.5.0
+ */
+export class LettermintTransport implements Transport {
+  /**
+   * The resolved Lettermint configuration used by this transport.
+   */
+  config: ResolvedLettermintConfig;
+
+  private httpClient: LettermintHttpClient;
+
+  /**
+   * Creates a new Lettermint transport instance.
+   *
+   * @param config Lettermint configuration including API token and options.
+   */
+  constructor(config: LettermintConfig) {
+    this.config = createLettermintConfig(config);
+    this.httpClient = new LettermintHttpClient(this.config);
+  }
+
+  /**
+   * Sends a single email message via Lettermint API.
+   *
+   * @param message The email message to send.
+   * @param options Optional transport options including `AbortSignal`.
+   * @returns A receipt indicating success or failure.
+   */
+  async send(message: Message, options?: TransportOptions): Promise<Receipt> {
+    try {
+      options?.signal?.throwIfAborted();
+
+      const emailData = await convertMessage(message, this.config);
+      const idempotencyKey = message.idempotencyKey ?? generateIdempotencyKey();
+
+      options?.signal?.throwIfAborted();
+
+      const response = await this.httpClient.sendMessage(
+        emailData,
+        options?.signal,
+        idempotencyKey,
+      );
+
+      return {
+        successful: true,
+        messageId: response.message_id,
+      };
+    } catch (error) {
+      return {
+        successful: false,
+        errorMessages: [error instanceof Error ? error.message : String(error)],
+      };
+    }
+  }
+
+  /**
+   * Sends multiple email messages via Lettermint batch API.
+   *
+   * Messages are chunked into Lettermint's maximum batch size of 500 messages.
+   *
+   * @param messages An iterable or async iterable of messages to send.
+   * @param options Optional transport options including `AbortSignal`.
+   * @returns An async iterable of receipts, one for each message.
+   */
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt> {
+    options?.signal?.throwIfAborted();
+
+    if (Symbol.asyncIterator in messages) {
+      let chunk: Message[] = [];
+      for await (const message of messages as AsyncIterable<Message>) {
+        options?.signal?.throwIfAborted();
+        chunk.push(message);
+        if (chunk.length === MAX_BATCH_SIZE) {
+          yield* this.sendBatch(chunk, options);
+          chunk = [];
+        }
+      }
+      yield* this.sendBatch(chunk, options);
+    } else {
+      let chunk: Message[] = [];
+      for (const message of messages as Iterable<Message>) {
+        options?.signal?.throwIfAborted();
+        chunk.push(message);
+        if (chunk.length === MAX_BATCH_SIZE) {
+          yield* this.sendBatch(chunk, options);
+          chunk = [];
+        }
+      }
+      yield* this.sendBatch(chunk, options);
+    }
+  }
+
+  private async *sendBatch(
+    messages: readonly Message[],
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt> {
+    if (messages.length === 0) return;
+
+    try {
+      const idempotencyKey = messages[0]?.idempotencyKey ??
+        generateIdempotencyKey();
+      const batchData = await Promise.all(
+        messages.map((message) => convertMessage(message, this.config)),
+      );
+
+      options?.signal?.throwIfAborted();
+
+      const response = await this.httpClient.sendBatch(
+        batchData,
+        options?.signal,
+        idempotencyKey,
+      );
+
+      for (let index = 0; index < messages.length; index++) {
+        const result = response[index];
+        if (result?.message_id) {
+          yield {
+            successful: true,
+            messageId: result.message_id,
+          };
+        } else {
+          yield {
+            successful: false,
+            errorMessages: [
+              "Lettermint batch response is missing a message ID.",
+            ],
+          };
+        }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
+      for (let i = 0; i < messages.length; i++) {
+        yield {
+          successful: false,
+          errorMessages: [errorMessage],
+        };
+      }
+    }
+  }
+}

--- a/packages/lettermint/src/lettermint-transport.ts
+++ b/packages/lettermint/src/lettermint-transport.ts
@@ -2,7 +2,11 @@ import type { Message, Receipt, Transport, TransportOptions } from "@upyo/core";
 import type { LettermintConfig, ResolvedLettermintConfig } from "./config.ts";
 import { createLettermintConfig } from "./config.ts";
 import { LettermintHttpClient } from "./http-client.ts";
-import { convertMessage, generateIdempotencyKey } from "./message-converter.ts";
+import {
+  convertMessage,
+  generateIdempotencyKey,
+  type LettermintEmail,
+} from "./message-converter.ts";
 
 const MAX_BATCH_SIZE = 500;
 
@@ -116,9 +120,29 @@ export class LettermintTransport implements Transport {
     try {
       const idempotencyKey = messages[0]?.idempotencyKey ??
         generateIdempotencyKey();
-      const batchData = await Promise.all(
-        messages.map((message) => convertMessage(message, this.config)),
-      );
+      const batchData: LettermintEmail[] = [];
+      const receipts: (Receipt | undefined)[] = [];
+
+      for (const message of messages) {
+        try {
+          batchData.push(await convertMessage(message, this.config));
+          receipts.push(undefined);
+        } catch (error) {
+          receipts.push({
+            successful: false,
+            errorMessages: [
+              error instanceof Error ? error.message : String(error),
+            ],
+          });
+        }
+      }
+
+      if (batchData.length === 0) {
+        for (const receipt of receipts) {
+          if (receipt !== undefined) yield receipt;
+        }
+        return;
+      }
 
       options?.signal?.throwIfAborted();
 
@@ -128,21 +152,30 @@ export class LettermintTransport implements Transport {
         idempotencyKey,
       );
 
-      for (let index = 0; index < messages.length; index++) {
-        const result = response[index];
+      let responseIndex = 0;
+      for (let index = 0; index < receipts.length; index++) {
+        const receipt = receipts[index];
+        if (receipt !== undefined) {
+          yield receipt;
+          continue;
+        }
+
+        const result = response[responseIndex++];
+        let responseReceipt: Receipt;
         if (result?.message_id) {
-          yield {
+          responseReceipt = {
             successful: true,
             messageId: result.message_id,
           };
         } else {
-          yield {
+          responseReceipt = {
             successful: false,
             errorMessages: [
               "Lettermint batch response is missing a message ID.",
             ],
           };
         }
+        yield responseReceipt;
       }
     } catch (error) {
       const errorMessage = error instanceof Error

--- a/packages/lettermint/src/lettermint-transport.ts
+++ b/packages/lettermint/src/lettermint-transport.ts
@@ -119,6 +119,13 @@ export class LettermintTransport implements Transport {
   ): AsyncIterable<Receipt> {
     if (messages.length === 0) return;
 
+    if (messages.some(hasIdempotencyKey)) {
+      for (const message of messages) {
+        yield await this.send(message, options);
+      }
+      return;
+    }
+
     const idempotencyKey = normalizeIdempotencyKey(
       messages[0]?.idempotencyKey,
     );
@@ -189,6 +196,10 @@ function normalizeIdempotencyKey(idempotencyKey: string | undefined): string {
   return idempotencyKey != null && idempotencyKey !== ""
     ? idempotencyKey
     : generateIdempotencyKey();
+}
+
+function hasIdempotencyKey(message: Message): boolean {
+  return message.idempotencyKey != null && message.idempotencyKey !== "";
 }
 
 function responseToReceipt(response: LettermintResponse | undefined): Receipt {

--- a/packages/lettermint/src/message-converter.test.ts
+++ b/packages/lettermint/src/message-converter.test.ts
@@ -232,6 +232,34 @@ describe("convertMessage", () => {
       "text/calendar; method=REQUEST",
     );
   });
+
+  it("uses native Uint8Array base64 conversion when available", async () => {
+    const content = new Uint8Array([1, 2, 3]);
+    Object.defineProperty(content, "toBase64", {
+      configurable: true,
+      value(this: Uint8Array) {
+        assert.deepEqual([...this], [1, 2, 3]);
+        return "native-base64";
+      },
+    });
+
+    const result = await convertMessage(
+      createBaseMessage({
+        attachments: [
+          {
+            filename: "native.bin",
+            content,
+            contentType: "application/octet-stream",
+            inline: false,
+            contentId: "",
+          },
+        ],
+      }),
+      baseConfig,
+    );
+
+    assert.equal(result.attachments?.[0]?.content, "native-base64");
+  });
 });
 
 describe("generateIdempotencyKey", () => {

--- a/packages/lettermint/src/message-converter.test.ts
+++ b/packages/lettermint/src/message-converter.test.ts
@@ -239,4 +239,23 @@ describe("generateIdempotencyKey", () => {
     const key = generateIdempotencyKey();
     assert.ok(key.length > 10);
   });
+
+  it("falls back when global crypto is unavailable", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+
+    Object.defineProperty(globalThis, "crypto", {
+      value: undefined,
+      configurable: true,
+    });
+    try {
+      const key = generateIdempotencyKey();
+      assert.ok(key.length > 10);
+    } finally {
+      if (descriptor == null) {
+        delete (globalThis as { crypto?: Crypto }).crypto;
+      } else {
+        Object.defineProperty(globalThis, "crypto", descriptor);
+      }
+    }
+  });
 });

--- a/packages/lettermint/src/message-converter.test.ts
+++ b/packages/lettermint/src/message-converter.test.ts
@@ -1,0 +1,225 @@
+import type { Message } from "@upyo/core";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createLettermintConfig } from "./config.ts";
+import { convertMessage, generateIdempotencyKey } from "./message-converter.ts";
+
+const baseConfig = createLettermintConfig({ apiToken: "test-token" });
+
+function createBaseMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    sender: { address: "sender@example.com" },
+    recipients: [{ address: "recipient@example.com" }],
+    ccRecipients: [],
+    bccRecipients: [],
+    replyRecipients: [],
+    subject: "Test Subject",
+    content: { text: "Test content" },
+    attachments: [],
+    priority: "normal",
+    tags: [],
+    headers: new Headers(),
+    ...overrides,
+  };
+}
+
+describe("convertMessage", () => {
+  it("converts a basic text message", async () => {
+    const result = await convertMessage(createBaseMessage(), baseConfig);
+
+    assert.equal(result.from, "sender@example.com");
+    assert.deepEqual(result.to, ["recipient@example.com"]);
+    assert.equal(result.subject, "Test Subject");
+    assert.equal(result.text, "Test content");
+    assert.equal(result.html, undefined);
+  });
+
+  it("formats addresses with names", async () => {
+    const result = await convertMessage(
+      createBaseMessage({
+        sender: { address: "sender@example.com", name: "Sender Name" },
+        recipients: [{
+          address: "recipient@example.com",
+          name: 'Recipient "Name"',
+        }],
+      }),
+      baseConfig,
+    );
+
+    assert.equal(result.from, '"Sender Name" <sender@example.com>');
+    assert.deepEqual(result.to, [
+      '"Recipient \\"Name\\"" <recipient@example.com>',
+    ]);
+  });
+
+  it("converts HTML content with text alternative", async () => {
+    const result = await convertMessage(
+      createBaseMessage({
+        content: { html: "<h1>Hello</h1>", text: "Hello" },
+      }),
+      baseConfig,
+    );
+
+    assert.equal(result.html, "<h1>Hello</h1>");
+    assert.equal(result.text, "Hello");
+  });
+
+  it("handles CC, BCC, and reply-to recipients", async () => {
+    const result = await convertMessage(
+      createBaseMessage({
+        ccRecipients: [{ address: "cc@example.com" }],
+        bccRecipients: [{ address: "bcc@example.com" }],
+        replyRecipients: [{ address: "reply@example.com" }],
+      }),
+      baseConfig,
+    );
+
+    assert.deepEqual(result.cc, ["cc@example.com"]);
+    assert.deepEqual(result.bcc, ["bcc@example.com"]);
+    assert.deepEqual(result.reply_to, ["reply@example.com"]);
+  });
+
+  it("applies Lettermint defaults from config", async () => {
+    const config = createLettermintConfig({
+      apiToken: "test-token",
+      route: "transactional",
+      tag: "welcome",
+      metadata: {
+        user_id: "123",
+        campaign_id: "welcome-2026",
+      },
+      settings: {
+        trackOpens: false,
+        trackClicks: true,
+      },
+    });
+
+    const result = await convertMessage(createBaseMessage(), config);
+
+    assert.equal(result.route, "transactional");
+    assert.equal(result.tag, "welcome");
+    assert.deepEqual(result.metadata, {
+      user_id: "123",
+      campaign_id: "welcome-2026",
+    });
+    assert.deepEqual(result.settings, {
+      track_opens: false,
+      track_clicks: true,
+    });
+  });
+
+  it("lets a single message tag override config tag", async () => {
+    const config = createLettermintConfig({
+      apiToken: "test-token",
+      tag: "default-tag",
+    });
+
+    const result = await convertMessage(
+      createBaseMessage({ tags: ["message-tag"] }),
+      config,
+    );
+
+    assert.equal(result.tag, "message-tag");
+  });
+
+  it("rejects messages with multiple tags", async () => {
+    await assert.rejects(
+      () =>
+        convertMessage(
+          createBaseMessage({ tags: ["one", "two"] }),
+          baseConfig,
+        ),
+      {
+        name: "RangeError",
+        message: "Lettermint supports at most one tag per message.",
+      },
+    );
+  });
+
+  it("converts priority and custom headers", async () => {
+    const headers = new Headers();
+    headers.set("X-Custom-Header", "custom-value");
+    headers.set("Subject", "ignored");
+
+    const result = await convertMessage(
+      createBaseMessage({
+        priority: "high",
+        headers,
+      }),
+      baseConfig,
+    );
+
+    assert.deepEqual(result.headers, {
+      "X-Priority": "1",
+      "x-custom-header": "custom-value",
+    });
+  });
+
+  it("converts attachments to base64 with inline content IDs", async () => {
+    const result = await convertMessage(
+      createBaseMessage({
+        attachments: [
+          {
+            filename: "hello.txt",
+            content: new TextEncoder().encode("hello"),
+            contentType: "text/plain",
+            inline: false,
+            contentId: "",
+          },
+          {
+            filename: "logo.png",
+            content: new Uint8Array([1, 2, 3]),
+            contentType: "image/png",
+            inline: true,
+            contentId: "logo",
+          },
+        ],
+      }),
+      baseConfig,
+    );
+
+    assert.deepEqual(result.attachments, [
+      {
+        filename: "hello.txt",
+        content: "aGVsbG8=",
+        content_type: "text/plain",
+      },
+      {
+        filename: "logo.png",
+        content: "AQID",
+        content_type: "image/png",
+        content_id: "logo",
+      },
+    ]);
+  });
+
+  it("preserves attachment content types with parameters", async () => {
+    const result = await convertMessage(
+      createBaseMessage({
+        attachments: [
+          {
+            filename: "invite.ics",
+            content: new TextEncoder().encode("BEGIN:VCALENDAR"),
+            contentType:
+              "text/calendar; method=REQUEST" as `${string}/${string}`,
+            inline: false,
+            contentId: "",
+          },
+        ],
+      }),
+      baseConfig,
+    );
+
+    assert.equal(
+      result.attachments?.[0]?.content_type,
+      "text/calendar; method=REQUEST",
+    );
+  });
+});
+
+describe("generateIdempotencyKey", () => {
+  it("generates non-empty keys", () => {
+    const key = generateIdempotencyKey();
+    assert.ok(key.length > 10);
+  });
+});

--- a/packages/lettermint/src/message-converter.test.ts
+++ b/packages/lettermint/src/message-converter.test.ts
@@ -52,6 +52,23 @@ describe("convertMessage", () => {
     ]);
   });
 
+  it("escapes backslashes in address display names", async () => {
+    const result = await convertMessage(
+      createBaseMessage({
+        sender: {
+          address: "sender@example.com",
+          name: String.raw`Sender \ "Name"`,
+        },
+      }),
+      baseConfig,
+    );
+
+    assert.equal(
+      result.from,
+      String.raw`"Sender \\ \"Name\"" <sender@example.com>`,
+    );
+  });
+
   it("converts HTML content with text alternative", async () => {
     const result = await convertMessage(
       createBaseMessage({

--- a/packages/lettermint/src/message-converter.test.ts
+++ b/packages/lettermint/src/message-converter.test.ts
@@ -237,25 +237,9 @@ describe("convertMessage", () => {
 describe("generateIdempotencyKey", () => {
   it("generates non-empty keys", () => {
     const key = generateIdempotencyKey();
-    assert.ok(key.length > 10);
-  });
-
-  it("falls back when global crypto is unavailable", () => {
-    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
-
-    Object.defineProperty(globalThis, "crypto", {
-      value: undefined,
-      configurable: true,
-    });
-    try {
-      const key = generateIdempotencyKey();
-      assert.ok(key.length > 10);
-    } finally {
-      if (descriptor == null) {
-        delete (globalThis as { crypto?: Crypto }).crypto;
-      } else {
-        Object.defineProperty(globalThis, "crypto", descriptor);
-      }
-    }
+    assert.match(
+      key,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
   });
 });

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -219,25 +219,16 @@ async function convertAttachment(
 }
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  const result: string[] = [];
+  const chunkSize = 0x8000;
+  let binary = "";
 
-  for (let i = 0; i < bytes.length; i += 3) {
-    const a = bytes[i];
-    const b = i + 1 < bytes.length ? bytes[i + 1] : 0;
-    const c = i + 2 < bytes.length ? bytes[i + 2] : 0;
-    const bitmap = (a << 16) | (b << 8) | c;
-
-    result.push(chars.charAt((bitmap >> 18) & 63));
-    result.push(chars.charAt((bitmap >> 12) & 63));
-    result.push(
-      i + 1 < bytes.length ? chars.charAt((bitmap >> 6) & 63) : "=",
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
     );
-    result.push(i + 2 < bytes.length ? chars.charAt(bitmap & 63) : "=");
   }
 
-  return result.join("");
+  return btoa(binary);
 }
 
 function isStandardHeader(headerName: string): boolean {
@@ -251,12 +242,5 @@ function isStandardHeader(headerName: string): boolean {
  * @since 0.5.0
  */
 export function generateIdempotencyKey(): string {
-  if (typeof globalThis.crypto?.randomUUID === "function") {
-    return globalThis.crypto.randomUUID();
-  }
-
-  const timestamp = Date.now().toString(36);
-  const random1 = Math.random().toString(36).slice(2);
-  const random2 = Math.random().toString(36).slice(2);
-  return `${timestamp}-${random1}${random2}`;
+  return globalThis.crypto.randomUUID();
 }

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -221,7 +221,7 @@ async function convertAttachment(
 function uint8ArrayToBase64(bytes: Uint8Array): string {
   const chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  let result = "";
+  const result: string[] = [];
 
   for (let i = 0; i < bytes.length; i += 3) {
     const a = bytes[i];
@@ -229,13 +229,15 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
     const c = i + 2 < bytes.length ? bytes[i + 2] : 0;
     const bitmap = (a << 16) | (b << 8) | c;
 
-    result += chars.charAt((bitmap >> 18) & 63);
-    result += chars.charAt((bitmap >> 12) & 63);
-    result += i + 1 < bytes.length ? chars.charAt((bitmap >> 6) & 63) : "=";
-    result += i + 2 < bytes.length ? chars.charAt(bitmap & 63) : "=";
+    result.push(chars.charAt((bitmap >> 18) & 63));
+    result.push(chars.charAt((bitmap >> 12) & 63));
+    result.push(
+      i + 1 < bytes.length ? chars.charAt((bitmap >> 6) & 63) : "=",
+    );
+    result.push(i + 2 < bytes.length ? chars.charAt(bitmap & 63) : "=");
   }
 
-  return result;
+  return result.join("");
 }
 
 function isStandardHeader(headerName: string): boolean {

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -1,0 +1,257 @@
+import type { Address, Attachment, Message } from "@upyo/core";
+import type { ResolvedLettermintConfig } from "./config.ts";
+
+/**
+ * Lettermint attachment object structure.
+ *
+ * @since 0.5.0
+ */
+export interface LettermintAttachment {
+  /** Attachment filename. */
+  readonly filename: string;
+  /** Base64-encoded attachment content. */
+  readonly content: string;
+  /** Attachment MIME type. */
+  readonly content_type: string;
+  /** Content-ID for inline attachments. */
+  readonly content_id?: string;
+}
+
+/**
+ * Lettermint settings payload structure.
+ *
+ * @since 0.5.0
+ */
+export interface LettermintSettingsPayload {
+  /** Whether Lettermint should track email opens. */
+  readonly track_opens?: boolean;
+  /** Whether Lettermint should track link clicks. */
+  readonly track_clicks?: boolean;
+}
+
+/**
+ * Lettermint email object structure for API requests.
+ *
+ * @since 0.5.0
+ */
+export interface LettermintEmail {
+  readonly from: string;
+  readonly to: readonly string[];
+  readonly subject: string;
+  readonly route?: string;
+  readonly tag?: string | null;
+  readonly html?: string;
+  readonly text?: string;
+  readonly cc?: readonly string[];
+  readonly bcc?: readonly string[];
+  readonly reply_to?: readonly string[];
+  readonly headers?: Record<string, string>;
+  readonly metadata?: Record<string, string>;
+  readonly settings?: LettermintSettingsPayload;
+  readonly attachments?: readonly LettermintAttachment[];
+}
+
+/**
+ * Converts an Upyo message to Lettermint API JSON format.
+ *
+ * @param message The Upyo message to convert.
+ * @param config The resolved Lettermint configuration.
+ * @returns JSON object ready for Lettermint API submission.
+ * @throws {RangeError} If the message has more than one tag.
+ * @since 0.5.0
+ */
+export async function convertMessage(
+  message: Message,
+  config: ResolvedLettermintConfig,
+): Promise<LettermintEmail> {
+  if (message.tags.length > 1) {
+    throw new RangeError(
+      "Lettermint supports at most one tag per message.",
+    );
+  }
+
+  const emailData: MutableLettermintEmail = {
+    from: formatAddress(message.sender),
+    to: message.recipients.map(formatAddress),
+    subject: message.subject,
+  };
+
+  if (message.ccRecipients.length > 0) {
+    emailData.cc = message.ccRecipients.map(formatAddress);
+  }
+
+  if (message.bccRecipients.length > 0) {
+    emailData.bcc = message.bccRecipients.map(formatAddress);
+  }
+
+  if (message.replyRecipients.length > 0) {
+    emailData.reply_to = message.replyRecipients.map(formatAddress);
+  }
+
+  if ("html" in message.content) {
+    emailData.html = message.content.html;
+    if (message.content.text) {
+      emailData.text = message.content.text;
+    }
+  } else {
+    emailData.text = message.content.text;
+  }
+
+  if (config.route) {
+    emailData.route = config.route;
+  }
+
+  if (message.tags.length === 1) {
+    emailData.tag = message.tags[0];
+  } else if (config.tag !== undefined) {
+    emailData.tag = config.tag;
+  }
+
+  if (config.metadata != null && Object.keys(config.metadata).length > 0) {
+    emailData.metadata = { ...config.metadata };
+  }
+
+  const settings = convertSettings(config);
+  if (settings != null) {
+    emailData.settings = settings;
+  }
+
+  const headers: Record<string, string> = {};
+  if (message.priority !== "normal") {
+    const priorityMap = {
+      "high": "1",
+      "normal": "3",
+      "low": "5",
+    };
+    headers["X-Priority"] = priorityMap[message.priority];
+  }
+
+  for (const [key, value] of message.headers.entries()) {
+    if (!isStandardHeader(key)) {
+      headers[key] = value;
+    }
+  }
+
+  if (Object.keys(headers).length > 0) {
+    emailData.headers = headers;
+  }
+
+  if (message.attachments.length > 0) {
+    emailData.attachments = await Promise.all(
+      message.attachments.map(convertAttachment),
+    );
+  }
+
+  return emailData;
+}
+
+type MutableLettermintEmail = {
+  -readonly [Key in keyof LettermintEmail]: LettermintEmail[Key];
+};
+
+function convertSettings(
+  config: ResolvedLettermintConfig,
+): LettermintSettingsPayload | undefined {
+  if (config.settings == null) return undefined;
+
+  const settings: {
+    track_opens?: boolean;
+    track_clicks?: boolean;
+  } = {};
+
+  if (config.settings.trackOpens !== undefined) {
+    settings.track_opens = config.settings.trackOpens;
+  }
+
+  if (config.settings.trackClicks !== undefined) {
+    settings.track_clicks = config.settings.trackClicks;
+  }
+
+  return Object.keys(settings).length > 0 ? settings : undefined;
+}
+
+function formatAddress(address: Address): string {
+  if (address.name) {
+    const escapedName = address.name.replace(/"/g, '\\"');
+    return `"${escapedName}" <${address.address}>`;
+  }
+  return address.address;
+}
+
+async function convertAttachment(
+  attachment: Attachment,
+): Promise<LettermintAttachment> {
+  const content = await attachment.content;
+  const converted: {
+    filename: string;
+    content: string;
+    content_type: string;
+    content_id?: string;
+  } = {
+    filename: attachment.filename,
+    content: uint8ArrayToBase64(content),
+    content_type: attachment.contentType,
+  };
+
+  if (attachment.inline && attachment.contentId) {
+    converted.content_id = attachment.contentId;
+  }
+
+  return converted;
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let result = "";
+
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i];
+    const b = i + 1 < bytes.length ? bytes[i + 1] : 0;
+    const c = i + 2 < bytes.length ? bytes[i + 2] : 0;
+    const bitmap = (a << 16) | (b << 8) | c;
+
+    result += chars.charAt((bitmap >> 18) & 63);
+    result += chars.charAt((bitmap >> 12) & 63);
+    result += i + 1 < bytes.length ? chars.charAt((bitmap >> 6) & 63) : "=";
+    result += i + 2 < bytes.length ? chars.charAt(bitmap & 63) : "=";
+  }
+
+  return result;
+}
+
+function isStandardHeader(headerName: string): boolean {
+  const standardHeaders = new Set([
+    "from",
+    "to",
+    "cc",
+    "bcc",
+    "reply-to",
+    "subject",
+    "date",
+    "message-id",
+    "content-type",
+    "content-transfer-encoding",
+    "mime-version",
+    "x-priority",
+  ]);
+
+  return standardHeaders.has(headerName.toLowerCase());
+}
+
+/**
+ * Generates a random idempotency key for request deduplication.
+ *
+ * @returns A unique string suitable for use as an idempotency key.
+ * @since 0.5.0
+ */
+export function generateIdempotencyKey(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  const timestamp = Date.now().toString(36);
+  const random1 = Math.random().toString(36).slice(2);
+  const random2 = Math.random().toString(36).slice(2);
+  return `${timestamp}-${random1}${random2}`;
+}

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -220,15 +220,15 @@ async function convertAttachment(
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
   const chunkSize = 0x8000;
-  let binary = "";
+  const chunks: string[] = [];
 
   for (let offset = 0; offset < bytes.length; offset += chunkSize) {
-    binary += String.fromCharCode(
-      ...bytes.subarray(offset, offset + chunkSize),
+    chunks.push(
+      String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)),
     );
   }
 
-  return btoa(binary);
+  return btoa(chunks.join(""));
 }
 
 function isStandardHeader(headerName: string): boolean {

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -164,6 +164,15 @@ type MutableLettermintEmail = {
   -readonly [Key in keyof LettermintEmail]: LettermintEmail[Key];
 };
 
+interface Base64Uint8Array extends Uint8Array {
+  toBase64(options?: Base64Options): string;
+}
+
+interface Base64Options {
+  readonly alphabet?: "base64" | "base64url";
+  readonly omitPadding?: boolean;
+}
+
 function convertSettings(
   config: ResolvedLettermintConfig,
 ): LettermintSettingsPayload | undefined {
@@ -219,6 +228,10 @@ async function convertAttachment(
 }
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
+  if (hasNativeToBase64(bytes)) {
+    return bytes.toBase64();
+  }
+
   const chunkSize = 0x8000;
   const chunks: string[] = [];
 
@@ -229,6 +242,11 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
   }
 
   return btoa(chunks.join(""));
+}
+
+function hasNativeToBase64(bytes: Uint8Array): bytes is Base64Uint8Array {
+  const candidate: Uint8Array & { readonly toBase64?: unknown } = bytes;
+  return typeof candidate.toBase64 === "function";
 }
 
 function isStandardHeader(headerName: string): boolean {

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -1,6 +1,21 @@
 import type { Address, Attachment, Message } from "@upyo/core";
 import type { ResolvedLettermintConfig } from "./config.ts";
 
+const STANDARD_HEADERS = new Set([
+  "from",
+  "to",
+  "cc",
+  "bcc",
+  "reply-to",
+  "subject",
+  "date",
+  "message-id",
+  "content-type",
+  "content-transfer-encoding",
+  "mime-version",
+  "x-priority",
+]);
+
 /**
  * Lettermint attachment object structure.
  *
@@ -172,7 +187,10 @@ function convertSettings(
 
 function formatAddress(address: Address): string {
   if (address.name) {
-    const escapedName = address.name.replace(/"/g, '\\"');
+    const escapedName = address.name.replace(/\\/g, "\\\\").replace(
+      /"/g,
+      '\\"',
+    );
     return `"${escapedName}" <${address.address}>`;
   }
   return address.address;
@@ -221,22 +239,7 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
 }
 
 function isStandardHeader(headerName: string): boolean {
-  const standardHeaders = new Set([
-    "from",
-    "to",
-    "cc",
-    "bcc",
-    "reply-to",
-    "subject",
-    "date",
-    "message-id",
-    "content-type",
-    "content-transfer-encoding",
-    "mime-version",
-    "x-priority",
-  ]);
-
-  return standardHeaders.has(headerName.toLowerCase());
+  return STANDARD_HEADERS.has(headerName.toLowerCase());
 }
 
 /**

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -164,13 +164,13 @@ type MutableLettermintEmail = {
   -readonly [Key in keyof LettermintEmail]: LettermintEmail[Key];
 };
 
-interface Base64Uint8Array extends Uint8Array {
-  toBase64(options?: Base64Options): string;
-}
-
 interface Base64Options {
   readonly alphabet?: "base64" | "base64url";
   readonly omitPadding?: boolean;
+}
+
+interface NativeBase64Converter {
+  toBase64?: (options?: Base64Options) => string;
 }
 
 function convertSettings(
@@ -228,8 +228,9 @@ async function convertAttachment(
 }
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
-  if (hasNativeToBase64(bytes)) {
-    return bytes.toBase64();
+  const nativeToBase64 = getNativeToBase64(bytes);
+  if (nativeToBase64 != null) {
+    return nativeToBase64();
   }
 
   const chunkSize = 0x8000;
@@ -244,9 +245,13 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
   return btoa(chunks.join(""));
 }
 
-function hasNativeToBase64(bytes: Uint8Array): bytes is Base64Uint8Array {
-  const candidate: Uint8Array & { readonly toBase64?: unknown } = bytes;
-  return typeof candidate.toBase64 === "function";
+function getNativeToBase64(
+  bytes: Uint8Array,
+): (() => string) | undefined {
+  const candidate: Uint8Array & NativeBase64Converter = bytes;
+  const toBase64 = candidate.toBase64;
+  if (typeof toBase64 !== "function") return undefined;
+  return () => toBase64.call(bytes);
 }
 
 function isStandardHeader(headerName: string): boolean {

--- a/packages/lettermint/src/message-converter.ts
+++ b/packages/lettermint/src/message-converter.ts
@@ -251,8 +251,8 @@ function isStandardHeader(headerName: string): boolean {
  * @since 0.5.0
  */
 export function generateIdempotencyKey(): string {
-  if (typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
   }
 
   const timestamp = Date.now().toString(36);

--- a/packages/lettermint/src/test-utils/test-config.ts
+++ b/packages/lettermint/src/test-utils/test-config.ts
@@ -1,0 +1,78 @@
+import type { Message } from "@upyo/core";
+import type { LettermintConfig } from "../config.ts";
+import process from "node:process";
+
+/**
+ * Lettermint E2E test configuration.
+ */
+export interface TestConfig {
+  readonly lettermint: LettermintConfig;
+  readonly from: `${string}@${string}`;
+  readonly to: `${string}@${string}`;
+}
+
+/**
+ * Checks whether Lettermint E2E testing is configured.
+ *
+ * @returns `true` if all required environment variables are present.
+ */
+export function isE2eTestingEnabled(): boolean {
+  return !!(
+    process.env.LETTERMINT_API_TOKEN &&
+    process.env.LETTERMINT_FROM &&
+    process.env.LETTERMINT_TO
+  );
+}
+
+/**
+ * Reads Lettermint E2E test configuration from environment variables.
+ *
+ * @returns Lettermint E2E test configuration.
+ * @throws {Error} If required environment variables are missing.
+ */
+export function getTestConfig(): TestConfig {
+  const apiToken = process.env.LETTERMINT_API_TOKEN;
+  const from = process.env.LETTERMINT_FROM;
+  const to = process.env.LETTERMINT_TO;
+
+  if (!apiToken || !from || !to) {
+    throw new Error(
+      "LETTERMINT_API_TOKEN, LETTERMINT_FROM, and LETTERMINT_TO are required.",
+    );
+  }
+
+  return {
+    lettermint: {
+      apiToken,
+      ...(process.env.LETTERMINT_BASE_URL && {
+        baseUrl: process.env.LETTERMINT_BASE_URL,
+      }),
+    },
+    from: from as `${string}@${string}`,
+    to: to as `${string}@${string}`,
+  };
+}
+
+/**
+ * Creates a test message for Lettermint E2E tests.
+ *
+ * @param overrides Message fields to override.
+ * @returns A test message.
+ */
+export function createTestMessage(overrides: Partial<Message> = {}): Message {
+  const config = getTestConfig();
+  return {
+    sender: { address: config.from, name: "Upyo Test" },
+    recipients: [{ address: config.to }],
+    ccRecipients: [],
+    bccRecipients: [],
+    replyRecipients: [],
+    subject: "[E2E] Lettermint test",
+    content: { text: "This is a test email sent through Lettermint." },
+    attachments: [],
+    priority: "normal",
+    tags: ["upyo-test"],
+    headers: new Headers(),
+    ...overrides,
+  };
+}

--- a/packages/lettermint/tsdown.config.ts
+++ b/packages/lettermint/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: "src/index.ts",
+  dts: true,
+  format: ["esm", "cjs"],
+  platform: "neutral",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@upyo/jmap':
         specifier: 'workspace:'
         version: link:../packages/jmap
+      '@upyo/lettermint':
+        specifier: 'workspace:'
+        version: link:../packages/lettermint
       '@upyo/mailgun':
         specifier: 'workspace:'
         version: link:../packages/mailgun
@@ -132,6 +135,22 @@ importers:
       jmap-rfc-types:
         specifier: ^0.1.2
         version: 0.1.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.12.9(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  packages/lettermint:
+    dependencies:
+      '@upyo/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@dotenvx/dotenvx':
+        specifier: 'catalog:'
+        version: 1.47.3
       tsdown:
         specifier: 'catalog:'
         version: 0.12.9(typescript@5.8.3)


### PR DESCRIPTION
## Summary

This PR adds a new Lettermint transport package for Upyo, available as `@upyo/lettermint`.

The new package in *packages/lettermint* includes configuration helpers, message conversion, HTTP API delivery, idempotency keys, retry handling, timeout handling, and batch sending. It also includes cross-runtime unit tests and optional E2E tests guarded by Lettermint environment variables.

The implementation preserves Upyo attachment MIME types when converting to Lettermint’s `content_type` field, retries internal request timeouts according to the configured retry count, and streams `sendMany()` input in 500-message chunks instead of buffering the whole iterable before sending.

## Documentation

This also documents the transport in *packages/lettermint/README.md* and *docs/transports/lettermint.md*, adds it to the root package list in *README.md*, wires it into the VitePress navigation in *docs/.vitepress/config.mts*, and records the change in *CHANGES.md*.

## Verification

- `deno task -c packages/lettermint/deno.json test-all`
- `deno task check`
- `cd docs && pnpm build`