### PR TITLE
Add OAuth 2.0 authentication to SMTP transport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,43 @@ To be released.
 [#22]: https://github.com/dahlia/upyo/issues/22
 [#23]: https://github.com/dahlia/upyo/pull/23
 
+### @upyo/smtp
+
+ -  Added OAuth 2.0 authentication support to the SMTP transport, using the
+    SASL *XOAUTH2* and *OAUTHBEARER* ([RFC 7628]) mechanisms.  This enables
+    authentication with providers such as Gmail and Outlook that require OAuth
+    2.0 instead of passwords.  [[#19]]
+
+     -  `SmtpAuth` is now a discriminated union of `SmtpUserPassAuth`
+        (username/password, as before) and the OAuth 2.0 variants.  Existing
+        `{ user, pass }` configurations continue to work unchanged.
+     -  Added `SmtpOAuth2Auth`, `SmtpOAuth2TokenAuth`, and
+        `SmtpOAuth2RefreshAuth` interfaces, and the `SmtpUserPassAuth`
+        interface.
+     -  Added the `OAuth2TokenProvider` type.  The `accessToken` field accepts
+        either a static token string or a callback returning a fresh token,
+        which can integrate an external OAuth client (e.g.,
+        `google-auth-library` or `msal-node`) for transparent refresh.
+     -  Added the built-in `refresh_token` grant flow
+        (`SmtpOAuth2RefreshAuth`): provide `clientId`, `refreshToken`, and
+        `tokenEndpoint`, and the transport exchanges them for an access token,
+        caching it across pooled connections until shortly before it expires.
+     -  Added the `SmtpAuthError` class, thrown on OAuth token acquisition and
+        SASL authentication failures.
+
+ -  Changed `SmtpTransport.send()` and `SmtpTransport.sendMany()` to report
+    connection and authentication setup failures as a failed `Receipt` instead
+    of throwing.  Previously, a failure to connect or authenticate (e.g., an
+    invalid host, a refused connection, or rejected credentials) rejected the
+    returned promise, which was inconsistent with message-level failures (such
+    as a rejected recipient) that were already reported as a failed `Receipt`.
+    Now all delivery failures—including setup failures—are reported uniformly
+    as a failed `Receipt`.  Cancellation via `AbortSignal` continues to reject.
+    [[#19]]
+
+[RFC 7628]: https://www.rfc-editor.org/rfc/rfc7628
+[#19]: https://github.com/dahlia/upyo/issues/19
+
 
 Version 0.4.0
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ To be released.
  -  Added OAuth 2.0 authentication support to the SMTP transport, using the
     SASL *XOAUTH2* and *OAUTHBEARER* ([RFC 7628]) mechanisms.  This enables
     authentication with providers such as Gmail and Outlook that require OAuth
-    2.0 instead of passwords.  [[#19]]
+    2.0 instead of passwords.  [[#19], [#24]]
 
      -  `SmtpAuth` is now a discriminated union of `SmtpUserPassAuth`
         (username/password, as before) and the OAuth 2.0 variants.  Existing
@@ -58,10 +58,11 @@ To be released.
     as a rejected recipient) that were already reported as a failed `Receipt`.
     Now all delivery failures—including setup failures—are reported uniformly
     as a failed `Receipt`.  Cancellation via `AbortSignal` continues to reject.
-    [[#19]]
+    [[#19], [#24]]
 
 [RFC 7628]: https://www.rfc-editor.org/rfc/rfc7628
 [#19]: https://github.com/dahlia/upyo/issues/19
+[#24]: https://github.com/dahlia/upyo/pull/24
 
 
 Version 0.4.0

--- a/docs/transports/smtp.md
+++ b/docs/transports/smtp.md
@@ -216,6 +216,87 @@ rather than using your regular account password.  The transport automatically
 detects server capabilities and chooses the appropriate authentication method
 if you don't specify one.
 
+### OAuth 2.0 authentication
+
+Many providers—including Gmail and Outlook—now require OAuth 2.0 instead of
+passwords.  The transport supports the SASL *XOAUTH2* mechanism (the de-facto
+standard used by Google and Microsoft) and *OAUTHBEARER* ([RFC 7628]).  Instead
+of `pass`, provide an `accessToken`:
+
+~~~~ typescript twoslash
+import { SmtpTransport } from "@upyo/smtp";
+
+const transport = new SmtpTransport({
+  host: "smtp.gmail.com",
+  port: 465,
+  secure: true,
+  auth: {
+    user: "your-email@gmail.com",
+    accessToken: "ya29.a0Af…your-access-token",
+  },
+});
+~~~~
+
+When `method` is omitted, the transport selects a mechanism advertised by the
+server, preferring *XOAUTH2*.  Set `method: "oauthbearer"` to force OAUTHBEARER.
+
+> [!IMPORTANT]
+> Always use OAuth 2.0 over a secure connection (`secure: true`, or STARTTLS on
+> port 587), since the access token is transmitted to the server.
+
+#### Refreshing tokens automatically
+
+Access tokens are short-lived, so a static string is rarely enough.  To refresh
+tokens transparently, pass a callback as `accessToken`.  It is invoked each time
+a new connection authenticates, which lets you delegate to an OAuth client such
+as [google-auth-library] (Gmail) or [msal-node] (Outlook):
+
+~~~~ typescript twoslash
+declare function getFreshAccessToken(): Promise<string>;
+// ---cut-before---
+import { SmtpTransport } from "@upyo/smtp";
+
+const transport = new SmtpTransport({
+  host: "smtp.gmail.com",
+  port: 465,
+  secure: true,
+  auth: {
+    user: "your-email@gmail.com",
+    // Called for every new connection; obtain a fresh token here.
+    accessToken: () => getFreshAccessToken(),
+  },
+});
+~~~~
+
+Alternatively, let the transport run the `refresh_token` grant itself.  Provide
+your client credentials, a refresh token, and the token endpoint; the transport
+exchanges them for an access token and caches it until shortly before it
+expires, sharing the cached token across all pooled connections:
+
+~~~~ typescript twoslash
+import { SmtpTransport } from "@upyo/smtp";
+
+const transport = new SmtpTransport({
+  host: "smtp.gmail.com",
+  port: 465,
+  secure: true,
+  auth: {
+    user: "your-email@gmail.com",
+    clientId: "…apps.googleusercontent.com",
+    clientSecret: "GOCSPX-…",
+    refreshToken: "1//…",
+    tokenEndpoint: "https://oauth2.googleapis.com/token",
+  },
+});
+~~~~
+
+Because a connection authenticates once when it is established, the callback or
+refresh runs per new connection rather than per message.
+
+[RFC 7628]: https://www.rfc-editor.org/rfc/rfc7628
+[google-auth-library]: https://github.com/googleapis/google-auth-library-nodejs
+[msal-node]: https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-node
+
 
 TLS and security configuration
 ------------------------------

--- a/docs/transports/smtp.md
+++ b/docs/transports/smtp.md
@@ -241,8 +241,9 @@ When `method` is omitted, the transport selects a mechanism advertised by the
 server, preferring *XOAUTH2*.  Set `method: "oauthbearer"` to force OAUTHBEARER.
 
 > [!IMPORTANT]
-> Always use OAuth 2.0 over a secure connection (`secure: true`, or STARTTLS on
-> port 587), since the access token is transmitted to the server.
+> OAuth 2.0 requires a secure connection (`secure: true`, or STARTTLS on port
+> 587), since the access token is transmitted to the server.  Authenticating
+> over a cleartext connection to a non-loopback host is refused.
 
 #### Refreshing tokens automatically
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -281,7 +281,7 @@ N/A
 | Feature                  | Upyo | [Nodemailer] | [Resend] | [SendGrid] | [Mailgun] |
 | ------------------------ | :--: | :----------: | :------: | :--------: | :-------: |
 | DKIM signing             |  ✅  |      ✅      |   N/A    |    N/A     |    N/A    |
-| OAuth 2.0 authentication |  🔜  |      ✅      |   N/A    |    N/A     |    N/A    |
+| OAuth 2.0 authentication |  ✅  |      ✅      |   N/A    |    N/A     |    N/A    |
 | Template engine          |  ❌  |    ❌[^2]    |    ✅    |     ✅     |    ✅     |
 
 #### Developer experience
@@ -320,8 +320,6 @@ Upyo is a great choice when you need:
 
 Consider other libraries when you need:
 
- -  *OAuth 2.0 authentication*: Nodemailer has mature support for this feature
-    (Upyo support is planned).
  -  *Built-in templating*: Resend (React), SendGrid, and Mailgun offer
     integrated template engines.
  -  *Node.js-only deployment*: Nodemailer's extensive plugin ecosystem may

--- a/packages/smtp/README.md
+++ b/packages/smtp/README.md
@@ -22,6 +22,7 @@ Features
  -  TLS/SSL support
  -  Connection pooling
  -  Multiple authentication methods
+ -  OAuth 2.0 authentication (SASL XOAUTH2 and OAUTHBEARER)
  -  HTML and plain text email support
  -  File attachments (regular and inline)
  -  Multiple recipients (To, CC, BCC)
@@ -116,11 +117,45 @@ Configuration options
 
 ### `SmtpAuth`
 
+`SmtpAuth` is a discriminated union of three strategies.
+
+Username/password (`SmtpUserPassAuth`), discriminated by `pass`:
+
 | Option   | Type                               | Default   | Description |
 | -------- | ---------------------------------- | --------- | ----------- |
 | `user`   | `string`                           |           | Username    |
 | `pass`   | `string`                           |           | Password    |
 | `method` | `"plain" \| "login" \| "cram-md5"` | `"plain"` | Auth method |
+
+OAuth 2.0 access token (`SmtpOAuth2TokenAuth`), discriminated by `accessToken`:
+
+| Option        | Type                            | Default     | Description                                 |
+| ------------- | ------------------------------- | ----------- | ------------------------------------------- |
+| `user`        | `string`                        |             | User (email address)                        |
+| `accessToken` | `string \| OAuth2TokenProvider` |             | Access token, or a callback returning one   |
+| `method`      | `"xoauth2" \| "oauthbearer"`    | `"xoauth2"` | SASL mechanism (auto-detected when omitted) |
+
+OAuth 2.0 refresh-token flow (`SmtpOAuth2RefreshAuth`), discriminated by
+`refreshToken`:
+
+| Option          | Type                         | Default     | Description                                 |
+| --------------- | ---------------------------- | ----------- | ------------------------------------------- |
+| `user`          | `string`                     |             | User (email address)                        |
+| `clientId`      | `string`                     |             | OAuth 2.0 client identifier                 |
+| `clientSecret`  | `string`                     |             | OAuth 2.0 client secret (optional)          |
+| `refreshToken`  | `string`                     |             | OAuth 2.0 refresh token                     |
+| `tokenEndpoint` | `string`                     |             | Token endpoint URL                          |
+| `scope`         | `string`                     |             | Space-delimited scopes (optional)           |
+| `method`        | `"xoauth2" \| "oauthbearer"` | `"xoauth2"` | SASL mechanism (auto-detected when omitted) |
+
+The access token may be a static string or a callback (`OAuth2TokenProvider`)
+that returns a fresh token on demand—use the callback to integrate an OAuth
+client such as `google-auth-library` or `msal-node`.  With the refresh-token
+flow the transport runs the `refresh_token` grant itself, caching the access
+token across pooled connections.  See the
+[OAuth 2.0 authentication guide][oauth-guide] for details.
+
+[oauth-guide]: https://upyo.org/transports/smtp#oauth-2-0-authentication
 
 
 DKIM signing
@@ -197,3 +232,40 @@ console.log(received[0].data); // Raw email content
 
 await server.stop();
 ~~~~
+
+### OAuth 2.0 end-to-end tests
+
+The OAuth 2.0 end-to-end tests run against a real provider (e.g. Gmail or
+Outlook) and are skipped unless the following environment variables are set:
+
+| Variable                | Description                            |
+| ----------------------- | -------------------------------------- |
+| `SMTP_OAUTH2_HOST`      | SMTP host (e.g. `smtp.gmail.com`)      |
+| `SMTP_OAUTH2_PORT`      | SMTP port (default `587`)              |
+| `SMTP_OAUTH2_SECURE`    | `true` for implicit TLS                |
+| `SMTP_OAUTH2_USER`      | User (email address)                   |
+| `SMTP_OAUTH2_MECHANISM` | `xoauth2` or `oauthbearer` (optional)  |
+| `SMTP_OAUTH2_FROM`      | Envelope sender (defaults to the user) |
+| `SMTP_OAUTH2_TO`        | Recipient (defaults to the user)       |
+
+Provide a token source as either a static access token:
+
+| Variable                   | Description        |
+| -------------------------- | ------------------ |
+| `SMTP_OAUTH2_ACCESS_TOKEN` | OAuth access token |
+
+or the refresh-token flow:
+
+| Variable                     | Description                       |
+| ---------------------------- | --------------------------------- |
+| `SMTP_OAUTH2_CLIENT_ID`      | OAuth client identifier           |
+| `SMTP_OAUTH2_CLIENT_SECRET`  | OAuth client secret (optional)    |
+| `SMTP_OAUTH2_REFRESH_TOKEN`  | OAuth refresh token               |
+| `SMTP_OAUTH2_TOKEN_ENDPOINT` | Token endpoint URL                |
+| `SMTP_OAUTH2_SCOPE`          | Space-delimited scopes (optional) |
+
+A Gmail access token can be minted with [google-auth-library], and an Outlook
+one with [msal-node].
+
+[google-auth-library]: https://github.com/googleapis/google-auth-library-nodejs
+[msal-node]: https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-node

--- a/packages/smtp/src/config.ts
+++ b/packages/smtp/src/config.ts
@@ -90,19 +90,70 @@ export interface SmtpConfig {
 /**
  * Authentication configuration for SMTP connections.
  *
- * Defines the credentials and authentication method to use when
- * connecting to an SMTP server that requires authentication.
+ * This is a discriminated union of the supported authentication strategies:
+ *
+ *  -  {@link SmtpUserPassAuth}: traditional username/password authentication
+ *     (SASL `PLAIN`, `LOGIN`, …), discriminated by the `pass` field.
+ *  -  {@link SmtpOAuth2TokenAuth}: OAuth 2.0 authentication using a static or
+ *     dynamically provided access token, discriminated by the `accessToken`
+ *     field.
+ *  -  {@link SmtpOAuth2RefreshAuth}: OAuth 2.0 authentication using the built-in
+ *     `refresh_token` grant flow, discriminated by the `refreshToken` field.
  *
  * @example
  * ```typescript
- * const auth: SmtpAuth = {
+ * // Username/password
+ * const passwordAuth: SmtpAuth = {
+ *   user: 'username@domain.com',
+ *   pass: 'password',
+ *   method: 'plain' // or 'login', 'cram-md5'
+ * };
+ *
+ * // OAuth 2.0 with a (possibly refreshing) access token
+ * const tokenAuth: SmtpAuth = {
+ *   user: 'username@gmail.com',
+ *   accessToken: 'ya29.a0Af…',
+ *   method: 'xoauth2' // or 'oauthbearer'
+ * };
+ * ```
+ */
+export type SmtpAuth =
+  | SmtpUserPassAuth
+  | SmtpOAuth2TokenAuth
+  | SmtpOAuth2RefreshAuth;
+
+/**
+ * OAuth 2.0 access token aggregate that supplies access tokens on demand.
+ *
+ * The transport invokes the provider each time it needs to authenticate a new
+ * connection, which lets the caller plug in an external OAuth client (e.g.,
+ * `google-auth-library` or `msal-node`) and refresh expired tokens
+ * transparently.
+ *
+ * @param signal An optional {@link AbortSignal} to cancel token acquisition.
+ * @returns The OAuth 2.0 access token (bearer token), or a promise of it.
+ * @since 0.5.0
+ */
+export type OAuth2TokenProvider = (
+  signal?: AbortSignal,
+) => string | Promise<string>;
+
+/**
+ * Username/password authentication configuration for SMTP connections.
+ *
+ * Defines the credentials and SASL method to use when connecting to an SMTP
+ * server that requires password-based authentication.
+ *
+ * @example
+ * ```typescript
+ * const auth: SmtpUserPassAuth = {
  *   user: 'username@domain.com',
  *   pass: 'password',
  *   method: 'plain' // or 'login', 'cram-md5'
  * };
  * ```
  */
-export interface SmtpAuth {
+export interface SmtpUserPassAuth {
   /**
    * Username for authentication.
    */
@@ -119,6 +170,121 @@ export interface SmtpAuth {
    */
   readonly method?: "plain" | "login" | "cram-md5";
 }
+
+/**
+ * OAuth 2.0 authentication configuration using a directly supplied access
+ * token.
+ *
+ * The `accessToken` may be a static string or an {@link OAuth2TokenProvider}
+ * callback that returns a fresh token on demand.  Use the callback form to
+ * integrate an external OAuth client (such as `google-auth-library` or
+ * `msal-node`) so that expired tokens are refreshed automatically.
+ *
+ * @example
+ * ```typescript
+ * const auth: SmtpOAuth2TokenAuth = {
+ *   user: 'username@gmail.com',
+ *   accessToken: async () => await getFreshAccessToken(),
+ *   method: 'xoauth2',
+ * };
+ * ```
+ * @since 0.5.0
+ */
+export interface SmtpOAuth2TokenAuth {
+  /**
+   * The user (email address) to authenticate as.
+   */
+  readonly user: string;
+
+  /**
+   * The OAuth 2.0 access token, or a provider callback returning one.
+   *
+   * When a callback is given, it is invoked every time a new connection is
+   * authenticated, allowing the caller to refresh expired tokens.
+   */
+  readonly accessToken: string | OAuth2TokenProvider;
+
+  /**
+   * The SASL mechanism to use.  When omitted, the mechanism is chosen
+   * automatically based on the server's advertised capabilities, preferring
+   * `xoauth2`.
+   * @default "xoauth2"
+   */
+  readonly method?: "xoauth2" | "oauthbearer";
+}
+
+/**
+ * OAuth 2.0 authentication configuration using the built-in `refresh_token`
+ * grant flow.
+ *
+ * The transport exchanges the refresh token for an access token at the given
+ * token endpoint and caches it until shortly before it expires, refreshing it
+ * automatically as needed.  No external OAuth library is required.
+ *
+ * @example
+ * ```typescript
+ * const auth: SmtpOAuth2RefreshAuth = {
+ *   user: 'username@gmail.com',
+ *   clientId: '…apps.googleusercontent.com',
+ *   clientSecret: '…',
+ *   refreshToken: '1//…',
+ *   tokenEndpoint: 'https://oauth2.googleapis.com/token',
+ * };
+ * ```
+ * @since 0.5.0
+ */
+export interface SmtpOAuth2RefreshAuth {
+  /**
+   * The user (email address) to authenticate as.
+   */
+  readonly user: string;
+
+  /**
+   * The OAuth 2.0 client identifier.
+   */
+  readonly clientId: string;
+
+  /**
+   * The OAuth 2.0 client secret.  May be omitted for public clients (e.g.,
+   * clients using PKCE) that have no secret.
+   */
+  readonly clientSecret?: string;
+
+  /**
+   * The OAuth 2.0 refresh token used to obtain access tokens.
+   */
+  readonly refreshToken: string;
+
+  /**
+   * The token endpoint URL where the refresh token is exchanged for an access
+   * token (e.g., `https://oauth2.googleapis.com/token`).
+   */
+  readonly tokenEndpoint: string;
+
+  /**
+   * An optional space-delimited list of OAuth 2.0 scopes to request.
+   */
+  readonly scope?: string;
+
+  /**
+   * The SASL mechanism to use.  When omitted, the mechanism is chosen
+   * automatically based on the server's advertised capabilities, preferring
+   * `xoauth2`.
+   * @default "xoauth2"
+   */
+  readonly method?: "xoauth2" | "oauthbearer";
+}
+
+/**
+ * OAuth 2.0 authentication configuration for SMTP connections.
+ *
+ * A union of the OAuth 2.0 authentication strategies: a directly supplied
+ * (or callback-provided) access token ({@link SmtpOAuth2TokenAuth}) or the
+ * built-in `refresh_token` grant flow ({@link SmtpOAuth2RefreshAuth}).
+ *
+ * @since 0.5.0
+ */
+export type SmtpOAuth2Auth = SmtpOAuth2TokenAuth | SmtpOAuth2RefreshAuth;
 
 /**
  * TLS/SSL configuration options for secure SMTP connections.

--- a/packages/smtp/src/index.ts
+++ b/packages/smtp/src/index.ts
@@ -1,5 +1,15 @@
 export { SmtpTransport } from "./smtp-transport.ts";
-export type { SmtpAuth, SmtpConfig, SmtpTlsOptions } from "./config.ts";
+export type {
+  OAuth2TokenProvider,
+  SmtpAuth,
+  SmtpConfig,
+  SmtpOAuth2Auth,
+  SmtpOAuth2RefreshAuth,
+  SmtpOAuth2TokenAuth,
+  SmtpTlsOptions,
+  SmtpUserPassAuth,
+} from "./config.ts";
+export { SmtpAuthError } from "./oauth2.ts";
 export type {
   DkimAlgorithm,
   DkimCanonicalization,

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -283,6 +283,40 @@ describe("OAuth2TokenManager", () => {
     assert.equal(calls, 2);
   });
 
+  test("falls back to the default lifetime for invalid expires_in", async () => {
+    for (const expiresIn of [-100, "100abc", "-5", null]) {
+      let calls = 0;
+      const fetchFn: typeof fetch = () => {
+        calls++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ access_token: "t", expires_in: expiresIn }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      };
+      const auth: SmtpOAuth2RefreshAuth = {
+        user: "u@e.com",
+        clientId: "client-id",
+        refreshToken: "refresh-token",
+        tokenEndpoint: "https://oauth2.example.com/token",
+      };
+      const manager = new OAuth2TokenManager(auth, fetchFn);
+
+      // An invalid value yields the default (~1h) lifetime, so the cached token
+      // is reused and there is no second fetch.
+      await manager.getAccessToken();
+      await manager.getAccessToken();
+      assert.equal(
+        calls,
+        1,
+        `expires_in=${
+          JSON.stringify(expiresIn)
+        } should use the default lifetime`,
+      );
+    }
+  });
+
   test("truncates an oversized error response body", async () => {
     const fetchFn: typeof fetch = () =>
       Promise.resolve(new Response("E".repeat(5000), { status: 502 }));

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -285,6 +285,8 @@ describe("OAuth2TokenManager", () => {
     const manager = new OAuth2TokenManager(auth);
     await assert.rejects(
       manager.getAccessToken(AbortSignal.abort()),
+      (error: unknown) =>
+        error instanceof DOMException && error.name === "AbortError",
     );
   });
 
@@ -330,6 +332,7 @@ describe("OAuth2TokenManager", () => {
         "https://oauth2.example.com/token",
         "http://localhost:8080/token",
         "http://127.0.0.1:8080/token",
+        "http://[::1]:8080/token",
       ]
     ) {
       const manager = new OAuth2TokenManager({

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -96,6 +96,15 @@ describe("selectOAuth2Mechanism()", () => {
     assert.equal(selectOAuth2Mechanism(["AUTH PLAIN LOGIN"]), "xoauth2");
     assert.equal(selectOAuth2Mechanism([]), "xoauth2");
   });
+
+  test("handles the AUTH= capability form", () => {
+    // The first mechanism is glued to the keyword, e.g. `AUTH=XOAUTH2 ...`.
+    assert.equal(
+      selectOAuth2Mechanism(["AUTH=XOAUTH2 OAUTHBEARER"]),
+      "xoauth2",
+    );
+    assert.equal(selectOAuth2Mechanism(["AUTH=OAUTHBEARER"]), "oauthbearer");
+  });
 });
 
 describe("OAuth2TokenManager", () => {

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -309,7 +309,7 @@ describe("OAuth2TokenManager", () => {
   });
 
   test("falls back to the default lifetime for invalid expires_in", async () => {
-    for (const expiresIn of [-100, "100abc", "-5", null]) {
+    for (const expiresIn of [-100, "100abc", "-5", "Infinity", "1e309", null]) {
       let calls = 0;
       const fetchFn: typeof fetch = () => {
         calls++;

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -258,6 +258,31 @@ describe("OAuth2TokenManager", () => {
     );
   });
 
+  test("parses a string expires_in", async () => {
+    let calls = 0;
+    const fetchFn: typeof fetch = () => {
+      calls++;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: `t${calls}`, expires_in: "0" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    };
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+
+    // "0" must parse to an immediate expiry, forcing a second fetch.
+    assert.equal(await manager.getAccessToken(), "t1");
+    assert.equal(await manager.getAccessToken(), "t2");
+    assert.equal(calls, 2);
+  });
+
   test("truncates an oversized error response body", async () => {
     const fetchFn: typeof fetch = () =>
       Promise.resolve(new Response("E".repeat(5000), { status: 502 }));

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { SmtpOAuth2RefreshAuth, SmtpOAuth2TokenAuth } from "./config.ts";
+import {
+  formatOauthbearer,
+  formatXoauth2,
+  OAuth2TokenManager,
+  selectOAuth2Mechanism,
+  SmtpAuthError,
+} from "./oauth2.ts";
+
+// Decodes a base64 string back to its raw bytes as a Latin-1 string so that the
+// 0x01 (^A) separators are preserved for assertions.
+function decodeBase64(value: string): string {
+  const binary = atob(value);
+  return binary;
+}
+
+describe("formatXoauth2()", () => {
+  test("matches the published Google XOAUTH2 vector", () => {
+    // From https://developers.google.com/workspace/gmail/imap/xoauth2-protocol
+    const result = formatXoauth2(
+      "someuser@example.com",
+      "ya29.vF9dft4qmTc2Nvb3RlckBhdHRhdmlzdGEuY29tCg",
+    );
+    assert.equal(
+      result,
+      "dXNlcj1zb21ldXNlckBleGFtcGxlLmNvbQFhdXRoPUJlYXJlciB5YTI5LnZGOWRm" +
+        "dDRxbVRjMk52YjNSbGNrQmhkSFJoZG1semRHRXVZMjl0Q2cBAQ==",
+    );
+  });
+
+  test("produces the documented control-character layout", () => {
+    const decoded = decodeBase64(formatXoauth2("u@e.com", "tok"));
+    assert.equal(decoded, "user=u@e.com\x01auth=Bearer tok\x01\x01");
+  });
+
+  test("encodes non-ASCII users without throwing", () => {
+    const decoded = decodeBase64(formatXoauth2("관리자@example.com", "tok"));
+    // UTF-8 bytes of the Hangul characters must be preserved.
+    const expected = new TextEncoder().encode(
+      "user=관리자@example.com\x01auth=Bearer tok\x01\x01",
+    );
+    const actual = Uint8Array.from(decoded, (c) => c.charCodeAt(0));
+    assert.deepEqual(actual, expected);
+  });
+});
+
+describe("formatOauthbearer()", () => {
+  test("matches the RFC 7628 OAUTHBEARER vector", () => {
+    // From RFC 7628 §4.1.
+    const result = formatOauthbearer(
+      "user@example.com",
+      "vF9dft4qmTc2Nvb3RlckBhbHRhdmlzdGEuY29tCg==",
+      "server.example.com",
+      587,
+    );
+    assert.equal(
+      result,
+      "bixhPXVzZXJAZXhhbXBsZS5jb20sAWhvc3Q9c2VydmVyLmV4YW1wbGUuY29tAXBv" +
+        "cnQ9NTg3AWF1dGg9QmVhcmVyIHZGOWRmdDRxbVRjMk52YjNSbGNrQmhiSFJoZG1s" +
+        "emRHRXVZMjl0Q2c9PQEB",
+    );
+  });
+
+  test("omits host and port when not provided", () => {
+    const decoded = decodeBase64(formatOauthbearer("u@e.com", "tok"));
+    assert.equal(decoded, "n,a=u@e.com,\x01auth=Bearer tok\x01\x01");
+  });
+});
+
+describe("selectOAuth2Mechanism()", () => {
+  test("prefers XOAUTH2 when both are advertised", () => {
+    assert.equal(
+      selectOAuth2Mechanism(["AUTH PLAIN LOGIN XOAUTH2 OAUTHBEARER", "HELP"]),
+      "xoauth2",
+    );
+  });
+
+  test("falls back to OAUTHBEARER when XOAUTH2 is absent", () => {
+    assert.equal(
+      selectOAuth2Mechanism(["AUTH PLAIN OAUTHBEARER"]),
+      "oauthbearer",
+    );
+  });
+
+  test("defaults to xoauth2 when neither is advertised", () => {
+    assert.equal(selectOAuth2Mechanism(["AUTH PLAIN LOGIN"]), "xoauth2");
+    assert.equal(selectOAuth2Mechanism([]), "xoauth2");
+  });
+});
+
+describe("OAuth2TokenManager", () => {
+  test("returns a static access token verbatim", async () => {
+    const auth: SmtpOAuth2TokenAuth = {
+      user: "u@e.com",
+      accessToken: "static-token",
+    };
+    const manager = new OAuth2TokenManager(auth);
+    assert.equal(await manager.getAccessToken(), "static-token");
+  });
+
+  test("invokes a synchronous token provider", async () => {
+    let calls = 0;
+    const auth: SmtpOAuth2TokenAuth = {
+      user: "u@e.com",
+      accessToken: () => {
+        calls++;
+        return "provided";
+      },
+    };
+    const manager = new OAuth2TokenManager(auth);
+    assert.equal(await manager.getAccessToken(), "provided");
+    await manager.getAccessToken();
+    assert.equal(calls, 2, "provider is called for every authentication");
+  });
+
+  test("invokes an asynchronous token provider", async () => {
+    const auth: SmtpOAuth2TokenAuth = {
+      user: "u@e.com",
+      accessToken: () => Promise.resolve("async-token"),
+    };
+    const manager = new OAuth2TokenManager(auth);
+    assert.equal(await manager.getAccessToken(), "async-token");
+  });
+
+  test("exchanges a refresh token and caches the result", async () => {
+    let calls = 0;
+    let lastBody: URLSearchParams | undefined;
+    const fetchFn: typeof fetch = (_input, init) => {
+      calls++;
+      lastBody = init?.body as URLSearchParams;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: "fresh-token", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    };
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+      scope: "https://mail.google.com/",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+
+    assert.equal(await manager.getAccessToken(), "fresh-token");
+    assert.equal(calls, 1);
+    assert.equal(lastBody?.get("grant_type"), "refresh_token");
+    assert.equal(lastBody?.get("client_id"), "client-id");
+    assert.equal(lastBody?.get("client_secret"), "client-secret");
+    assert.equal(lastBody?.get("refresh_token"), "refresh-token");
+    assert.equal(lastBody?.get("scope"), "https://mail.google.com/");
+
+    // Second call within the validity window must reuse the cached token.
+    assert.equal(await manager.getAccessToken(), "fresh-token");
+    assert.equal(calls, 1, "cached token is reused; no second fetch");
+  });
+
+  test("refetches when the cached token is (near) expiry", async () => {
+    let calls = 0;
+    const fetchFn: typeof fetch = () => {
+      calls++;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: `t${calls}`, expires_in: 0 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    };
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+
+    assert.equal(await manager.getAccessToken(), "t1");
+    assert.equal(await manager.getAccessToken(), "t2");
+    assert.equal(calls, 2);
+  });
+
+  test("coalesces concurrent refreshes into a single request", async () => {
+    let calls = 0;
+    const fetchFn: typeof fetch = () => {
+      calls++;
+      return new Promise<Response>((resolve) =>
+        setTimeout(
+          () =>
+            resolve(
+              new Response(
+                JSON.stringify({
+                  access_token: "shared-token",
+                  expires_in: 3600,
+                }),
+                {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                },
+              ),
+            ),
+          10,
+        )
+      );
+    };
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+
+    const tokens = await Promise.all([
+      manager.getAccessToken(),
+      manager.getAccessToken(),
+      manager.getAccessToken(),
+    ]);
+    assert.deepEqual(tokens, ["shared-token", "shared-token", "shared-token"]);
+    assert.equal(
+      calls,
+      1,
+      "concurrent refreshes are coalesced into one request",
+    );
+  });
+
+  test("throws SmtpAuthError on a non-OK token response", async () => {
+    const fetchFn: typeof fetch = () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+    await assert.rejects(
+      manager.getAccessToken(),
+      (error: unknown) =>
+        error instanceof SmtpAuthError && /invalid_grant/.test(error.message),
+    );
+  });
+
+  test("rejects when the abort signal is already aborted", async () => {
+    const auth: SmtpOAuth2TokenAuth = {
+      user: "u@e.com",
+      accessToken: "static-token",
+    };
+    const manager = new OAuth2TokenManager(auth);
+    await assert.rejects(
+      manager.getAccessToken(AbortSignal.abort()),
+    );
+  });
+
+  test("preserves abort errors during the refresh request", async () => {
+    const controller = new AbortController();
+    const fetchFn: typeof fetch = () => {
+      // Simulate the request being aborted mid-flight.
+      controller.abort();
+      return Promise.reject(
+        new DOMException("The operation was aborted.", "AbortError"),
+      );
+    };
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+    await assert.rejects(
+      manager.getAccessToken(controller.signal),
+      (error: unknown) =>
+        error instanceof DOMException && error.name === "AbortError",
+    );
+  });
+
+  test("rejects an insecure (non-HTTPS) token endpoint", () => {
+    assert.throws(
+      () =>
+        new OAuth2TokenManager({
+          user: "u@e.com",
+          clientId: "client-id",
+          refreshToken: "refresh-token",
+          tokenEndpoint: "http://oauth2.example.com/token",
+        }),
+      TypeError,
+    );
+  });
+
+  test("allows HTTPS and loopback HTTP token endpoints", () => {
+    for (
+      const tokenEndpoint of [
+        "https://oauth2.example.com/token",
+        "http://localhost:8080/token",
+        "http://127.0.0.1:8080/token",
+      ]
+    ) {
+      const manager = new OAuth2TokenManager({
+        user: "u@e.com",
+        clientId: "client-id",
+        refreshToken: "refresh-token",
+        tokenEndpoint,
+      });
+      assert.ok(manager instanceof OAuth2TokenManager);
+    }
+  });
+});

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -67,6 +67,14 @@ describe("formatOauthbearer()", () => {
     const decoded = decodeBase64(formatOauthbearer("u@e.com", "tok"));
     assert.equal(decoded, "n,a=u@e.com,\x01auth=Bearer tok\x01\x01");
   });
+
+  test("escapes commas and equals signs in the authzid", () => {
+    const decoded = decodeBase64(formatOauthbearer("a,b=c@example.com", "tok"));
+    assert.equal(
+      decoded,
+      "n,a=a=2Cb=3Dc@example.com,\x01auth=Bearer tok\x01\x01",
+    );
+  });
 });
 
 describe("selectOAuth2Mechanism()", () => {

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -351,6 +351,32 @@ describe("OAuth2TokenManager", () => {
     }
   });
 
+  test("reuses short-lived tokens within their lifetime", async () => {
+    let calls = 0;
+    const fetchFn: typeof fetch = () => {
+      calls++;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: `t${calls}`, expires_in: 30 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    };
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+
+    // The safety margin is capped at half the lifetime, so a 30s token is
+    // cached rather than refreshed on every call.
+    assert.equal(await manager.getAccessToken(), "t1");
+    assert.equal(await manager.getAccessToken(), "t1");
+    assert.equal(calls, 1);
+  });
+
   test("truncates an oversized error response body", async () => {
     const fetchFn: typeof fetch = () =>
       Promise.resolve(new Response("E".repeat(5000), { status: 502 }));

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -258,6 +258,25 @@ describe("OAuth2TokenManager", () => {
     );
   });
 
+  test("truncates an oversized error response body", async () => {
+    const fetchFn: typeof fetch = () =>
+      Promise.resolve(new Response("E".repeat(5000), { status: 502 }));
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, fetchFn);
+    await assert.rejects(
+      manager.getAccessToken(),
+      (error: unknown) =>
+        error instanceof SmtpAuthError &&
+        error.message.includes("…") &&
+        error.message.length < 700,
+    );
+  });
+
   test("rejects when the abort signal is already aborted", async () => {
     const auth: SmtpOAuth2TokenAuth = {
       user: "u@e.com",

--- a/packages/smtp/src/oauth2.test.ts
+++ b/packages/smtp/src/oauth2.test.ts
@@ -168,6 +168,31 @@ describe("OAuth2TokenManager", () => {
     assert.equal(calls, 1, "cached token is reused; no second fetch");
   });
 
+  test("calls fetchFn without binding it to the manager", async () => {
+    const receivers: unknown[] = [];
+    function recordingFetch(this: unknown): Promise<Response> {
+      receivers.push(this);
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: "t", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }
+    const auth: SmtpOAuth2RefreshAuth = {
+      user: "u@e.com",
+      clientId: "client-id",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    };
+    const manager = new OAuth2TokenManager(auth, recordingFetch);
+    await manager.getAccessToken();
+
+    // The native fetch throws "Illegal invocation" if called as a method, so
+    // it must be invoked unbound (receiver undefined), not as `this.fetchFn`.
+    assert.equal(receivers[0], undefined);
+  });
+
   test("refetches when the cached token is (near) expiry", async () => {
     let calls = 0;
     const fetchFn: typeof fetch = () => {

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -200,9 +200,15 @@ function truncateErrorBody(text: string): string {
 function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
   if (signal == null) return promise;
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(signal.reason);
+    // Fall back to a standard AbortError when the signal has no reason (e.g.
+    // aborted without one, or a runtime that does not populate `reason`), so the
+    // promise never rejects with `undefined`.
+    const abortReason = () =>
+      signal.reason ??
+        new DOMException("The operation was aborted.", "AbortError");
+    const onAbort = () => reject(abortReason());
     if (signal.aborted) {
-      reject(signal.reason);
+      reject(abortReason());
     } else {
       signal.addEventListener("abort", onAbort, { once: true });
     }

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -115,9 +115,11 @@ export function selectOAuth2Mechanism(
   const authLine = capabilities.find((cap) =>
     cap.toUpperCase().startsWith("AUTH")
   );
+  // Normalize "=" to whitespace so the older `AUTH=XOAUTH2 ...` form (where the
+  // first mechanism is glued to the AUTH keyword) is parsed like `AUTH XOAUTH2`.
   const mechanisms = authLine == null
     ? []
-    : authLine.toUpperCase().split(/\s+/).slice(1);
+    : authLine.toUpperCase().replace(/=/g, " ").split(/\s+/).slice(1);
   if (mechanisms.includes("XOAUTH2")) return "xoauth2";
   if (mechanisms.includes("OAUTHBEARER")) return "oauthbearer";
   return "xoauth2";

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -77,11 +77,23 @@ export function formatOauthbearer(
   host?: string,
   port?: number,
 ): string {
-  let response = `n,a=${user},\x01`;
+  let response = `n,a=${escapeSaslName(user)},\x01`;
   if (host != null) response += `host=${host}\x01`;
   if (port != null) response += `port=${port}\x01`;
   response += `auth=Bearer ${accessToken}\x01\x01`;
   return toBase64(response);
+}
+
+/**
+ * Escapes a SASL name (GS2 `authzid`) per RFC 5801, encoding `,` as `=2C` and
+ * `=` as `=3D` so that identities containing those characters do not corrupt
+ * the GS2 header.
+ *
+ * @param name The SASL name to escape.
+ * @returns The escaped SASL name.
+ */
+function escapeSaslName(name: string): string {
+  return name.replace(/=/g, "=3D").replace(/,/g, "=2C");
 }
 
 /**

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -164,6 +164,28 @@ const REFRESH_SAFETY_MARGIN_MS = 60_000;
 const DEFAULT_EXPIRES_IN = 3600;
 
 /**
+ * How long to wait for the token endpoint before aborting the request, so a
+ * stalled endpoint cannot block authentication indefinitely.
+ */
+const TOKEN_REQUEST_TIMEOUT_MS = 60_000;
+
+/** Maximum number of response-body characters to include in error messages. */
+const MAX_ERROR_BODY_LENGTH = 500;
+
+/**
+ * Truncates a token-endpoint response body so an oversized payload (e.g. a
+ * large proxy/CDN error page) does not bloat error messages and logs.
+ *
+ * @param text The response body text.
+ * @returns The text, truncated with an ellipsis if it exceeds the limit.
+ */
+function truncateErrorBody(text: string): string {
+  return text.length > MAX_ERROR_BODY_LENGTH
+    ? `${text.slice(0, MAX_ERROR_BODY_LENGTH)}…`
+    : text;
+}
+
+/**
  * Mirrors a promise but rejects early if the given abort signal fires, without
  * cancelling the underlying promise.  This lets a single waiter abort its own
  * wait on a shared operation without affecting other waiters.
@@ -297,6 +319,13 @@ export class OAuth2TokenManager {
     if (auth.clientSecret != null) body.set("client_secret", auth.clientSecret);
     if (auth.scope != null) body.set("scope", auth.scope);
 
+    // Bound the request with an internal timeout so a stalled endpoint cannot
+    // leave the shared `pending` promise unresolved forever.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort(new Error("OAuth 2.0 token request timed out"));
+    }, TOKEN_REQUEST_TIMEOUT_MS);
+
     let response: Response;
     try {
       response = await this.fetchFn(auth.tokenEndpoint, {
@@ -306,6 +335,7 @@ export class OAuth2TokenManager {
           "accept": "application/json",
         },
         body,
+        signal: controller.signal,
       });
     } catch (cause) {
       throw new SmtpAuthError(
@@ -313,12 +343,15 @@ export class OAuth2TokenManager {
           `${auth.tokenEndpoint}: ` +
           `${cause instanceof Error ? cause.message : String(cause)}`,
       );
+    } finally {
+      clearTimeout(timeout);
     }
 
     const text = await response.text();
+    const safeText = truncateErrorBody(text);
     if (!response.ok) {
       throw new SmtpAuthError(
-        `OAuth 2.0 token endpoint responded with HTTP ${response.status}: ${text}`,
+        `OAuth 2.0 token endpoint responded with HTTP ${response.status}: ${safeText}`,
       );
     }
 
@@ -327,7 +360,7 @@ export class OAuth2TokenManager {
       json = JSON.parse(text);
     } catch {
       throw new SmtpAuthError(
-        `OAuth 2.0 token endpoint returned a non-JSON response: ${text}`,
+        `OAuth 2.0 token endpoint returned a non-JSON response: ${safeText}`,
       );
     }
 
@@ -336,7 +369,7 @@ export class OAuth2TokenManager {
       typeof (json as Record<string, unknown>).access_token !== "string"
     ) {
       throw new SmtpAuthError(
-        `OAuth 2.0 token endpoint response did not include an access_token: ${text}`,
+        `OAuth 2.0 token endpoint response did not include an access_token: ${safeText}`,
       );
     }
 

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -1,0 +1,337 @@
+import type { SmtpOAuth2Auth, SmtpOAuth2RefreshAuth } from "./config.ts";
+
+/**
+ * An error thrown when SMTP authentication fails, including OAuth 2.0 token
+ * acquisition and SASL exchange failures.
+ *
+ * @since 0.5.0
+ */
+export class SmtpAuthError extends Error {
+  /**
+   * Creates a new {@link SmtpAuthError}.
+   * @param message A human-readable description of the failure.
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "SmtpAuthError";
+  }
+}
+
+/**
+ * Encodes a string as Base64 in a cross-runtime, UTF-8-safe manner.
+ *
+ * Unlike calling `btoa()` directly, this first encodes the input as UTF-8 so
+ * that non-ASCII characters (e.g., in an internationalized address) do not
+ * throw.
+ *
+ * @param input The string to encode.
+ * @returns The Base64-encoded representation of the UTF-8 bytes of `input`.
+ */
+function toBase64(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Builds the SASL `XOAUTH2` initial client response for SMTP authentication.
+ *
+ * The unencoded payload follows Google's XOAUTH2 format
+ * (`user=<user>^Aauth=Bearer <token>^A^A`, where `^A` is the `0x01` control
+ * character) and is returned Base64-encoded, ready to be sent as the argument
+ * of `AUTH XOAUTH2`.
+ *
+ * @param user The user (email address) to authenticate as.
+ * @param accessToken The OAuth 2.0 access token.
+ * @returns The Base64-encoded XOAUTH2 initial client response.
+ * @since 0.5.0
+ */
+export function formatXoauth2(user: string, accessToken: string): string {
+  return toBase64(`user=${user}\x01auth=Bearer ${accessToken}\x01\x01`);
+}
+
+/**
+ * Builds the SASL `OAUTHBEARER` initial client response for SMTP
+ * authentication, as defined by [RFC 7628].
+ *
+ * The unencoded payload is
+ * `n,a=<user>,^A[host=<host>^A][port=<port>^A]auth=Bearer <token>^A^A`
+ * (where `^A` is the `0x01` control character) and is returned Base64-encoded,
+ * ready to be sent as the argument of `AUTH OAUTHBEARER`.
+ *
+ * [RFC 7628]: https://www.rfc-editor.org/rfc/rfc7628
+ *
+ * @param user The user (email address) to authenticate as.
+ * @param accessToken The OAuth 2.0 access token.
+ * @param host The server host to include as the `host` key/value, if any.
+ * @param port The server port to include as the `port` key/value, if any.
+ * @returns The Base64-encoded OAUTHBEARER initial client response.
+ * @since 0.5.0
+ */
+export function formatOauthbearer(
+  user: string,
+  accessToken: string,
+  host?: string,
+  port?: number,
+): string {
+  let response = `n,a=${user},\x01`;
+  if (host != null) response += `host=${host}\x01`;
+  if (port != null) response += `port=${port}\x01`;
+  response += `auth=Bearer ${accessToken}\x01\x01`;
+  return toBase64(response);
+}
+
+/**
+ * Chooses an OAuth 2.0 SASL mechanism based on the mechanisms advertised by the
+ * server in its `AUTH` capability line.
+ *
+ * `XOAUTH2` is preferred when available (it is the de-facto standard supported
+ * by Gmail and Outlook); otherwise `OAUTHBEARER` is used when advertised.  When
+ * neither is advertised, `xoauth2` is returned as a best-effort default.
+ *
+ * @param capabilities The capability lines parsed from the server's EHLO
+ *                     response.
+ * @returns The selected mechanism, either `"xoauth2"` or `"oauthbearer"`.
+ * @since 0.5.0
+ */
+export function selectOAuth2Mechanism(
+  capabilities: readonly string[],
+): "xoauth2" | "oauthbearer" {
+  const authLine = capabilities.find((cap) =>
+    cap.toUpperCase().startsWith("AUTH")
+  );
+  const mechanisms = authLine == null
+    ? []
+    : authLine.toUpperCase().split(/\s+/).slice(1);
+  if (mechanisms.includes("XOAUTH2")) return "xoauth2";
+  if (mechanisms.includes("OAUTHBEARER")) return "oauthbearer";
+  return "xoauth2";
+}
+
+/**
+ * Validates that an OAuth 2.0 token endpoint is safe to send client credentials
+ * to, requiring HTTPS except for loopback addresses (for local testing).
+ *
+ * @param endpoint The token endpoint URL to validate.
+ * @throws {TypeError} If the URL is malformed or uses an insecure scheme.
+ */
+function assertSecureTokenEndpoint(endpoint: string): void {
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw new TypeError(
+      `Invalid OAuth 2.0 token endpoint URL: ${endpoint}`,
+    );
+  }
+  if (url.protocol === "https:") return;
+  const isLoopback = url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "[::1]" ||
+    url.hostname === "::1";
+  if (url.protocol === "http:" && isLoopback) return;
+  throw new TypeError(
+    "OAuth 2.0 token endpoint must use HTTPS to protect client credentials: " +
+      endpoint,
+  );
+}
+
+/**
+ * The number of milliseconds before a cached access token's expiry at which it
+ * is considered stale and eligible for refresh.
+ */
+const REFRESH_SAFETY_MARGIN_MS = 60_000;
+
+/**
+ * The default access token lifetime (in seconds) assumed when the token
+ * endpoint omits `expires_in`.
+ */
+const DEFAULT_EXPIRES_IN = 3600;
+
+/**
+ * Mirrors a promise but rejects early if the given abort signal fires, without
+ * cancelling the underlying promise.  This lets a single waiter abort its own
+ * wait on a shared operation without affecting other waiters.
+ *
+ * @param promise The promise to await.
+ * @param signal An optional abort signal that rejects the returned promise.
+ * @returns A promise that settles with `promise`, or rejects when `signal`
+ *          aborts.
+ */
+function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (signal == null) return promise;
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    if (signal.aborted) {
+      reject(signal.reason);
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    // Always attach to the underlying promise so its settlement is observed
+    // (avoiding unhandled rejections) even after an abort wins the race.
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
+ * Acquires and caches OAuth 2.0 access tokens for SMTP authentication.
+ *
+ * Depending on the {@link SmtpOAuth2Auth} configuration, the manager either
+ * returns a static token, invokes a provider callback on every request, or
+ * exchanges a refresh token for an access token at the configured token
+ * endpoint and caches it until shortly before it expires.  A single manager is
+ * shared across all pooled connections of a transport so that the refresh-token
+ * exchange happens at most once per token lifetime.
+ *
+ * @since 0.5.0
+ */
+export class OAuth2TokenManager {
+  private readonly auth: SmtpOAuth2Auth;
+  private readonly fetchFn: typeof fetch;
+  private cached?: { accessToken: string; expiresAt: number };
+  private pending?: Promise<{ accessToken: string; expiresIn: number }>;
+
+  /**
+   * Creates a new {@link OAuth2TokenManager}.
+   *
+   * @param auth The OAuth 2.0 authentication configuration.
+   * @param fetchFn The `fetch` implementation to use for the refresh-token
+   *                exchange.  Defaults to the global `fetch`; primarily
+   *                overridden in tests.
+   * @throws {TypeError} If a refresh-token configuration has an insecure
+   *                     (non-HTTPS) token endpoint.
+   */
+  constructor(auth: SmtpOAuth2Auth, fetchFn: typeof fetch = fetch) {
+    if ("refreshToken" in auth) {
+      assertSecureTokenEndpoint(auth.tokenEndpoint);
+    }
+    this.auth = auth;
+    this.fetchFn = fetchFn;
+  }
+
+  /**
+   * Returns a valid OAuth 2.0 access token, acquiring or refreshing it as
+   * needed.
+   *
+   * @param signal An optional {@link AbortSignal} to cancel token acquisition.
+   * @returns The current access token.
+   * @throws {SmtpAuthError} If a refresh-token exchange fails or returns an
+   *                         unexpected response.
+   */
+  async getAccessToken(signal?: AbortSignal): Promise<string> {
+    signal?.throwIfAborted();
+
+    const auth = this.auth;
+    if ("accessToken" in auth) {
+      return typeof auth.accessToken === "function"
+        ? await auth.accessToken(signal)
+        : auth.accessToken;
+    }
+
+    const cached = this.cached;
+    if (
+      cached != null && cached.expiresAt - REFRESH_SAFETY_MARGIN_MS > Date.now()
+    ) {
+      return cached.accessToken;
+    }
+
+    // Coalesce concurrent refreshes so the token endpoint is hit at most once
+    // per token lifetime.  The shared request is not tied to any single caller's
+    // abort signal; each caller instead races it against its own signal so that
+    // one caller's cancellation cannot fail the others.
+    this.pending ??= this.refresh(auth).finally(() => {
+      this.pending = undefined;
+    });
+
+    const { accessToken, expiresIn } = await abortable(this.pending, signal);
+    this.cached = {
+      accessToken,
+      expiresAt: Date.now() + expiresIn * 1000,
+    };
+    return accessToken;
+  }
+
+  /**
+   * Exchanges the configured refresh token for a fresh access token.
+   *
+   * The request deliberately runs without a caller-specific abort signal; it is
+   * shared across concurrent callers, each of which applies its own
+   * cancellation separately (see {@link getAccessToken}).
+   *
+   * @param auth The refresh-token authentication configuration.
+   * @returns The new access token and its lifetime in seconds.
+   * @throws {SmtpAuthError} If the request fails or the response is invalid.
+   */
+  private async refresh(
+    auth: SmtpOAuth2RefreshAuth,
+  ): Promise<{ accessToken: string; expiresIn: number }> {
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: auth.clientId,
+      refresh_token: auth.refreshToken,
+    });
+    if (auth.clientSecret != null) body.set("client_secret", auth.clientSecret);
+    if (auth.scope != null) body.set("scope", auth.scope);
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(auth.tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "accept": "application/json",
+        },
+        body,
+      });
+    } catch (cause) {
+      throw new SmtpAuthError(
+        `Failed to request an OAuth 2.0 access token from ` +
+          `${auth.tokenEndpoint}: ` +
+          `${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    }
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new SmtpAuthError(
+        `OAuth 2.0 token endpoint responded with HTTP ${response.status}: ${text}`,
+      );
+    }
+
+    let json: unknown;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      throw new SmtpAuthError(
+        `OAuth 2.0 token endpoint returned a non-JSON response: ${text}`,
+      );
+    }
+
+    if (
+      typeof json !== "object" || json == null ||
+      typeof (json as Record<string, unknown>).access_token !== "string"
+    ) {
+      throw new SmtpAuthError(
+        `OAuth 2.0 token endpoint response did not include an access_token: ${text}`,
+      );
+    }
+
+    const record = json as Record<string, unknown>;
+    const expiresIn = typeof record.expires_in === "number"
+      ? record.expires_in
+      : DEFAULT_EXPIRES_IN;
+    return { accessToken: record.access_token as string, expiresIn };
+  }
+}

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -334,6 +334,7 @@ export class OAuth2TokenManager {
     }, TOKEN_REQUEST_TIMEOUT_MS);
 
     let response: Response;
+    let text: string;
     try {
       response = await this.fetchFn(auth.tokenEndpoint, {
         method: "POST",
@@ -344,6 +345,9 @@ export class OAuth2TokenManager {
         body,
         signal: controller.signal,
       });
+      // Read the body under the same timeout: an endpoint that returns headers
+      // but stalls on the body must not leave `pending` unresolved forever.
+      text = await response.text();
     } catch (cause) {
       throw new SmtpAuthError(
         `Failed to request an OAuth 2.0 access token from ` +
@@ -354,7 +358,6 @@ export class OAuth2TokenManager {
       clearTimeout(timeout);
     }
 
-    const text = await response.text();
     const safeText = truncateErrorBody(text);
     if (!response.ok) {
       throw new SmtpAuthError(

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -285,15 +285,22 @@ export class OAuth2TokenManager {
     // per token lifetime.  The shared request is not tied to any single caller's
     // abort signal; each caller instead races it against its own signal so that
     // one caller's cancellation cannot fail the others.
-    this.pending ??= this.refresh(auth).finally(() => {
-      this.pending = undefined;
-    });
+    this.pending ??= this.refresh(auth)
+      .then((result) => {
+        // Populate the cache before `finally` clears `pending`, so a concurrent
+        // caller in the microtask gap finds the fresh token instead of starting
+        // a duplicate refresh.
+        this.cached = {
+          accessToken: result.accessToken,
+          expiresAt: Date.now() + result.expiresIn * 1000,
+        };
+        return result;
+      })
+      .finally(() => {
+        this.pending = undefined;
+      });
 
-    const { accessToken, expiresIn } = await abortable(this.pending, signal);
-    this.cached = {
-      accessToken,
-      expiresAt: Date.now() + expiresIn * 1000,
-    };
+    const { accessToken } = await abortable(this.pending, signal);
     return accessToken;
   }
 
@@ -374,9 +381,15 @@ export class OAuth2TokenManager {
     }
 
     const record = json as Record<string, unknown>;
-    const expiresIn = typeof record.expires_in === "number"
-      ? record.expires_in
-      : DEFAULT_EXPIRES_IN;
+    // Most providers return `expires_in` as a number, but some return it as a
+    // numeric string; parse that rather than falling back to the default.
+    let expiresIn = DEFAULT_EXPIRES_IN;
+    if (typeof record.expires_in === "number") {
+      expiresIn = record.expires_in;
+    } else if (typeof record.expires_in === "string") {
+      const parsed = Number.parseInt(record.expires_in, 10);
+      if (Number.isFinite(parsed)) expiresIn = parsed;
+    }
     return { accessToken: record.access_token as string, expiresIn };
   }
 }

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -283,9 +283,7 @@ export class OAuth2TokenManager {
     }
 
     const cached = this.cached;
-    if (
-      cached != null && cached.expiresAt - REFRESH_SAFETY_MARGIN_MS > Date.now()
-    ) {
+    if (cached != null && cached.expiresAt > Date.now()) {
       return cached.accessToken;
     }
 
@@ -297,10 +295,14 @@ export class OAuth2TokenManager {
       .then((result) => {
         // Populate the cache before `finally` clears `pending`, so a concurrent
         // caller in the microtask gap finds the fresh token instead of starting
-        // a duplicate refresh.
+        // a duplicate refresh.  Refresh slightly before expiry; cap the safety
+        // margin at half the lifetime so short-lived tokens are not treated as
+        // already expired (which would refresh on every connection).
+        const lifetimeMs = result.expiresIn * 1000;
+        const safetyMargin = Math.min(REFRESH_SAFETY_MARGIN_MS, lifetimeMs / 2);
         this.cached = {
           accessToken: result.accessToken,
-          expiresAt: Date.now() + result.expiresIn * 1000,
+          expiresAt: Date.now() + lifetimeMs - safetyMargin,
         };
         return result;
       })

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -384,15 +384,22 @@ export class OAuth2TokenManager {
     }
 
     const record = json as Record<string, unknown>;
-    // Most providers return `expires_in` as a number, but some return it as a
-    // numeric string; parse that rather than falling back to the default.
-    let expiresIn = DEFAULT_EXPIRES_IN;
-    if (typeof record.expires_in === "number") {
-      expiresIn = record.expires_in;
-    } else if (typeof record.expires_in === "string") {
-      const parsed = Number.parseInt(record.expires_in, 10);
-      if (Number.isFinite(parsed)) expiresIn = parsed;
+    // Accept `expires_in` only as a finite, non-negative number of seconds.
+    // Some providers send it as a numeric string; `Number()` (unlike
+    // `parseInt`) rejects partial parses like "100abc".  Negative, NaN, and
+    // Infinity values fall back to the default lifetime.
+    const rawExpiresIn = record.expires_in;
+    let parsedExpiresIn: number;
+    if (typeof rawExpiresIn === "number") {
+      parsedExpiresIn = rawExpiresIn;
+    } else if (typeof rawExpiresIn === "string" && rawExpiresIn.trim() !== "") {
+      parsedExpiresIn = Number(rawExpiresIn);
+    } else {
+      parsedExpiresIn = NaN;
     }
+    const expiresIn = Number.isFinite(parsedExpiresIn) && parsedExpiresIn >= 0
+      ? parsedExpiresIn
+      : DEFAULT_EXPIRES_IN;
     return { accessToken: record.access_token as string, expiresIn };
   }
 }

--- a/packages/smtp/src/oauth2.ts
+++ b/packages/smtp/src/oauth2.ts
@@ -335,8 +335,12 @@ export class OAuth2TokenManager {
 
     let response: Response;
     let text: string;
+    // Call through a local variable so the global `fetch` is not invoked as a
+    // method of this manager, which throws "Illegal invocation" in some
+    // runtimes (the native `fetch` requires a `globalThis`/undefined receiver).
+    const fetchFn = this.fetchFn;
     try {
-      response = await this.fetchFn(auth.tokenEndpoint, {
+      response = await fetchFn(auth.tokenEndpoint, {
         method: "POST",
         headers: {
           "content-type": "application/x-www-form-urlencoded",

--- a/packages/smtp/src/smtp-connection.integration.test.ts
+++ b/packages/smtp/src/smtp-connection.integration.test.ts
@@ -72,7 +72,11 @@ describe("SMTP Connection Integration Tests", () => {
 
         // Should have received capabilities
         assert.ok(connection.capabilities.length > 0);
-        assert.ok(connection.capabilities.includes("AUTH PLAIN LOGIN"));
+        assert.ok(
+          connection.capabilities.includes(
+            "AUTH PLAIN LOGIN XOAUTH2 OAUTHBEARER",
+          ),
+        );
       } finally {
         await teardownTest(server, connection);
       }

--- a/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
+++ b/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { SmtpConfig } from "./config.ts";
+import { SmtpConnection } from "./smtp-connection.ts";
+import { SmtpAuthError } from "./oauth2.ts";
+import { MockSmtpServer } from "./test-utils/mock-smtp-server.ts";
+
+describe("SMTP OAuth 2.0 authentication", () => {
+  async function setup(auth: SmtpConfig["auth"]) {
+    const server = new MockSmtpServer();
+    await server.start();
+    const config: SmtpConfig = {
+      host: "localhost",
+      port: server.getPort(),
+      secure: false,
+      connectionTimeout: 5000,
+      socketTimeout: 5000,
+      localName: "test.local",
+      auth,
+    };
+    const connection = new SmtpConnection(config);
+    return { server, connection };
+  }
+
+  async function teardown(server: MockSmtpServer, connection: SmtpConnection) {
+    try {
+      await connection.quit();
+    } catch {
+      // Ignore cleanup errors.
+    }
+    await server.stop();
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+
+  function decodeAuthInitialResponse(authCommand: string): string {
+    const parts = authCommand.split(" ");
+    return atob(parts[2]);
+  }
+
+  test("authenticates with XOAUTH2 using a static token", async () => {
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: "the-access-token",
+    });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+      await connection.authenticate();
+
+      assert.ok(connection.authenticated);
+      const command = server.getLastAuthCommand();
+      assert.ok(command != null);
+      assert.ok(command!.startsWith("AUTH XOAUTH2 "));
+      assert.equal(
+        decodeAuthInitialResponse(command!),
+        "user=user@example.com\x01auth=Bearer the-access-token\x01\x01",
+      );
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+
+  test("authenticates with XOAUTH2 using a synchronous token provider", async () => {
+    let called = false;
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: () => {
+        called = true;
+        return "provided-token";
+      },
+    });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+      await connection.authenticate();
+
+      assert.ok(connection.authenticated);
+      assert.ok(called);
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+
+  test("authenticates with XOAUTH2 using an asynchronous token provider", async () => {
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: () => Promise.resolve("async-token"),
+    });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+      await connection.authenticate();
+
+      assert.ok(connection.authenticated);
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+
+  test("rejects XOAUTH2 failure via the 334 challenge continuation", async () => {
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: "bad-token",
+    });
+    server.setResponse("AUTH", { code: 535, message: "5.7.8 Bad credentials" });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+
+      await assert.rejects(
+        connection.authenticate(),
+        (error: unknown) =>
+          error instanceof SmtpAuthError && /XOAUTH2/.test(error.message),
+      );
+      assert.ok(!connection.authenticated);
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+
+  test("authenticates with OAUTHBEARER including host and port", async () => {
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: "the-access-token",
+      method: "oauthbearer",
+    });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+      await connection.authenticate();
+
+      assert.ok(connection.authenticated);
+      const command = server.getLastAuthCommand();
+      assert.ok(command != null);
+      assert.ok(command!.startsWith("AUTH OAUTHBEARER "));
+      const decoded = decodeAuthInitialResponse(command!);
+      assert.ok(decoded.startsWith("n,a=user@example.com,\x01"));
+      assert.ok(decoded.includes("\x01host=localhost\x01"));
+      assert.ok(decoded.includes(`\x01port=${server.getPort()}\x01`));
+      assert.ok(decoded.endsWith("\x01auth=Bearer the-access-token\x01\x01"));
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+
+  test("rejects OAUTHBEARER failure via the 334 challenge continuation", async () => {
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: "bad-token",
+      method: "oauthbearer",
+    });
+    server.setResponse("AUTH", { code: 535, message: "5.7.8 Bad credentials" });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+
+      await assert.rejects(
+        connection.authenticate(),
+        (error: unknown) =>
+          error instanceof SmtpAuthError && /OAUTHBEARER/.test(error.message),
+      );
+      assert.ok(!connection.authenticated);
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+
+  test("auto-selects XOAUTH2 when method is omitted", async () => {
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: "the-access-token",
+    });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+      await connection.authenticate();
+
+      const command = server.getLastAuthCommand();
+      assert.ok(command!.startsWith("AUTH XOAUTH2 "));
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+});

--- a/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
+++ b/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
@@ -83,6 +83,28 @@ describe("SMTP OAuth 2.0 authentication", () => {
     }
   });
 
+  test("uses the two-step SASL form for an over-long XOAUTH2 token", async () => {
+    // A long token (e.g. an Outlook JWT) overflows the SMTP command-line limit,
+    // so the initial response must be sent on its own line after a 334.
+    const longToken = "x".repeat(800);
+    const { server, connection } = await setup({
+      user: "user@example.com",
+      accessToken: longToken,
+    });
+    try {
+      await connection.connect();
+      await connection.greeting();
+      await connection.ehlo();
+      await connection.authenticate();
+
+      assert.ok(connection.authenticated);
+      // The AUTH command carried no inline initial response.
+      assert.equal(server.getLastAuthCommand(), "AUTH XOAUTH2");
+    } finally {
+      await teardown(server, connection);
+    }
+  });
+
   test("authenticates with XOAUTH2 using an asynchronous token provider", async () => {
     const { server, connection } = await setup({
       user: "user@example.com",

--- a/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
+++ b/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
@@ -136,7 +136,10 @@ describe("SMTP OAuth 2.0 authentication", () => {
       await assert.rejects(
         connection.authenticate(),
         (error: unknown) =>
-          error instanceof SmtpAuthError && /XOAUTH2/.test(error.message),
+          error instanceof SmtpAuthError && /XOAUTH2/.test(error.message) &&
+          // The empty continuation was accepted, so the final server reply is
+          // the real failure rather than a rejected-continuation error.
+          /Bad credentials/.test(error.message),
       );
       assert.ok(!connection.authenticated);
     } finally {
@@ -185,7 +188,10 @@ describe("SMTP OAuth 2.0 authentication", () => {
       await assert.rejects(
         connection.authenticate(),
         (error: unknown) =>
-          error instanceof SmtpAuthError && /OAUTHBEARER/.test(error.message),
+          error instanceof SmtpAuthError && /OAUTHBEARER/.test(error.message) &&
+          // The "AQ==" continuation was accepted, so the final server reply is
+          // the real failure rather than a rejected-continuation error.
+          /Bad credentials/.test(error.message),
       );
       assert.ok(!connection.authenticated);
     } finally {

--- a/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
+++ b/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
@@ -241,4 +241,26 @@ describe("SMTP OAuth 2.0 authentication", () => {
       socket.destroy();
     }
   });
+
+  test("throws SmtpAuthError when the server lacks AUTH support", async () => {
+    const connection = new SmtpConnection({
+      host: "smtp.example.com",
+      port: 465,
+      secure: true,
+      auth: { user: "user@example.com", accessToken: "the-access-token" },
+    });
+    const socket = new Socket();
+    connection.socket = socket;
+    connection.capabilities = []; // server advertised no AUTH mechanisms
+    try {
+      await assert.rejects(
+        connection.authenticate(),
+        (error: unknown) =>
+          error instanceof SmtpAuthError &&
+          /does not support/.test(error.message),
+      );
+    } finally {
+      socket.destroy();
+    }
+  });
 });

--- a/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
+++ b/packages/smtp/src/smtp-connection.oauth2.integration.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { Socket } from "node:net";
 import { describe, test } from "node:test";
 import type { SmtpConfig } from "./config.ts";
 import { SmtpConnection } from "./smtp-connection.ts";
@@ -214,6 +215,30 @@ describe("SMTP OAuth 2.0 authentication", () => {
       assert.ok(command!.startsWith("AUTH XOAUTH2 "));
     } finally {
       await teardown(server, connection);
+    }
+  });
+
+  test("refuses OAuth over a cleartext non-loopback connection", async () => {
+    const connection = new SmtpConnection({
+      host: "smtp.example.com",
+      port: 25,
+      secure: false,
+      auth: { user: "user@example.com", accessToken: "the-access-token" },
+    });
+    // Simulate a post-EHLO plaintext connection without dialing out; the TLS
+    // guard rejects before the socket is used.
+    const socket = new Socket();
+    connection.socket = socket;
+    connection.capabilities = ["AUTH XOAUTH2"];
+    try {
+      await assert.rejects(
+        connection.authenticate(),
+        (error: unknown) =>
+          error instanceof SmtpAuthError && /TLS/.test(error.message),
+      );
+      assert.ok(!connection.authenticated);
+    } finally {
+      socket.destroy();
     }
   });
 });

--- a/packages/smtp/src/smtp-connection.ts
+++ b/packages/smtp/src/smtp-connection.ts
@@ -16,6 +16,15 @@ import {
 } from "./oauth2.ts";
 import type { SmtpMessage } from "./message-converter.ts";
 
+/**
+ * The maximum length of an SMTP command line, including the terminating CRLF,
+ * as specified by RFC 5321 §4.5.3.1.4.
+ */
+const MAX_COMMAND_LINE_LENGTH = 512;
+
+/** The length of the CRLF terminator appended to every command. */
+const CRLF_LENGTH = 2;
+
 export class SmtpConnection {
   socket: Socket | TLSSocket | null = null;
   config: ResolvedSmtpConfig;
@@ -361,8 +370,9 @@ export class SmtpConnection {
   ): Promise<void> {
     const token = await this.getOAuth2Token(auth, signal);
     const initialResponse = formatXoauth2(auth.user, token);
-    const response = await this.sendCommand(
-      `AUTH XOAUTH2 ${initialResponse}`,
+    const response = await this.sendSaslAuth(
+      "XOAUTH2",
+      initialResponse,
       signal,
     );
     // On failure XOAUTH2 servers send a 334 challenge; the client replies with
@@ -381,13 +391,45 @@ export class SmtpConnection {
       this.config.host,
       this.config.port,
     );
-    const response = await this.sendCommand(
-      `AUTH OAUTHBEARER ${initialResponse}`,
+    const response = await this.sendSaslAuth(
+      "OAUTHBEARER",
+      initialResponse,
       signal,
     );
     // RFC 7628: on failure the client replies with a single 0x01 ("AQ==") to
     // receive the final failure response.
     await this.finishOAuth2(response, "OAUTHBEARER", "AQ==", signal);
+  }
+
+  /**
+   * Sends a SASL `AUTH` command with its Base64 initial response.
+   *
+   * When the resulting command line would exceed the SMTP command-line length
+   * limit (e.g. a long Outlook JWT access token), RFC 4954 requires the client
+   * to omit the initial response and send it on its own line after the server's
+   * `334` challenge.  This method transparently falls back to that two-step
+   * form, since some servers reject the over-long single-line command outright.
+   *
+   * @param mechanism The SASL mechanism name (e.g. `XOAUTH2`).
+   * @param initialResponse The Base64-encoded initial client response.
+   * @param signal An optional {@link AbortSignal}.
+   * @returns The server's response to the initial response.
+   */
+  private async sendSaslAuth(
+    mechanism: string,
+    initialResponse: string,
+    signal?: AbortSignal,
+  ): Promise<SmtpResponse> {
+    const inlineCommand = `AUTH ${mechanism} ${initialResponse}`;
+    if (inlineCommand.length + CRLF_LENGTH <= MAX_COMMAND_LINE_LENGTH) {
+      return await this.sendCommand(inlineCommand, signal);
+    }
+
+    const challenge = await this.sendCommand(`AUTH ${mechanism}`, signal);
+    if (challenge.code !== 334) {
+      return challenge;
+    }
+    return await this.sendCommand(initialResponse, signal);
   }
 
   /**

--- a/packages/smtp/src/smtp-connection.ts
+++ b/packages/smtp/src/smtp-connection.ts
@@ -26,6 +26,13 @@ const MAX_COMMAND_LINE_LENGTH = 512;
 const CRLF_LENGTH = 2;
 
 /**
+ * How long, in milliseconds, to wait for the graceful `QUIT` to flush during
+ * teardown before giving up, so an unresponsive server cannot block shutdown
+ * for the full socket timeout.
+ */
+const QUIT_TIMEOUT_MS = 5000;
+
+/**
  * Whether a host refers to the local loopback interface, for which cleartext
  * OAuth 2.0 authentication is permitted (e.g. local testing and development).
  *
@@ -557,11 +564,21 @@ export class SmtpConnection {
     // finished connecting (e.g. a refused or timed-out connection) would
     // otherwise error or leave a dangling command timeout.
     if (socket.writable) {
-      try {
-        await this.sendCommand("QUIT");
-      } catch {
-        // Ignore errors during quit
-      }
+      // Send QUIT best-effort and wait only until it has been flushed (bounded
+      // by QUIT_TIMEOUT_MS) rather than for the server's reply, so an
+      // unresponsive server cannot block teardown for the full socket timeout.
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, QUIT_TIMEOUT_MS);
+        try {
+          socket.write("QUIT\r\n", () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        } catch {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
     }
 
     try {

--- a/packages/smtp/src/smtp-connection.ts
+++ b/packages/smtp/src/smtp-connection.ts
@@ -4,7 +4,16 @@ import {
   createSmtpConfig,
   type ResolvedSmtpConfig,
   type SmtpConfig,
+  type SmtpOAuth2Auth,
+  type SmtpUserPassAuth,
 } from "./config.ts";
+import {
+  formatOauthbearer,
+  formatXoauth2,
+  OAuth2TokenManager,
+  selectOAuth2Mechanism,
+  SmtpAuthError,
+} from "./oauth2.ts";
 import type { SmtpMessage } from "./message-converter.ts";
 
 export class SmtpConnection {
@@ -12,9 +21,11 @@ export class SmtpConnection {
   config: ResolvedSmtpConfig;
   authenticated = false;
   capabilities: string[] = [];
+  tokenManager: OAuth2TokenManager | null;
 
-  constructor(config: SmtpConfig) {
+  constructor(config: SmtpConfig, tokenManager?: OAuth2TokenManager) {
     this.config = createSmtpConfig(config);
+    this.tokenManager = tokenManager ?? null;
   }
 
   connect(signal?: AbortSignal): Promise<void> {
@@ -248,7 +259,8 @@ export class SmtpConnection {
   }
 
   async authenticate(signal?: AbortSignal): Promise<void> {
-    if (!this.config.auth) {
+    const auth = this.config.auth;
+    if (!auth) {
       return;
     }
 
@@ -256,30 +268,48 @@ export class SmtpConnection {
       return;
     }
 
-    const authMethod = this.config.auth.method ?? "plain";
-
     if (
       !this.capabilities.some((cap) => cap.toUpperCase().startsWith("AUTH"))
     ) {
-      throw new Error("Server does not support authentication");
+      throw new Error("Server does not support authentication.");
     }
 
-    switch (authMethod) {
-      case "plain":
-        await this.authPlain(signal);
-        break;
-      case "login":
-        await this.authLogin(signal);
-        break;
-      default:
-        throw new Error(`Unsupported authentication method: ${authMethod}`);
+    if ("accessToken" in auth || "refreshToken" in auth) {
+      const mechanism = auth.method ?? selectOAuth2Mechanism(this.capabilities);
+      switch (mechanism) {
+        case "xoauth2":
+          await this.authXoauth2(auth, signal);
+          break;
+        case "oauthbearer":
+          await this.authOauthbearer(auth, signal);
+          break;
+        default:
+          throw new SmtpAuthError(
+            `Unsupported authentication method: ${mechanism}`,
+          );
+      }
+    } else {
+      const method = auth.method ?? "plain";
+      switch (method) {
+        case "plain":
+          await this.authPlain(auth, signal);
+          break;
+        case "login":
+          await this.authLogin(auth, signal);
+          break;
+        default:
+          throw new Error(`Unsupported authentication method: ${method}`);
+      }
     }
 
     this.authenticated = true;
   }
 
-  private async authPlain(signal?: AbortSignal): Promise<void> {
-    const { user, pass } = this.config.auth!;
+  private async authPlain(
+    auth: SmtpUserPassAuth,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const { user, pass } = auth;
     const credentials = btoa(`\0${user}\0${pass}`);
     const response = await this.sendCommand(
       `AUTH PLAIN ${credentials}`,
@@ -291,8 +321,11 @@ export class SmtpConnection {
     }
   }
 
-  async authLogin(signal?: AbortSignal): Promise<void> {
-    const { user, pass } = this.config.auth!;
+  async authLogin(
+    auth: SmtpUserPassAuth,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const { user, pass } = auth;
 
     let response = await this.sendCommand("AUTH LOGIN", signal);
     if (response.code !== 334) {
@@ -308,6 +341,80 @@ export class SmtpConnection {
     if (response.code !== 235) {
       throw new Error(`Password authentication failed: ${response.message}`);
     }
+  }
+
+  /**
+   * Resolves an OAuth 2.0 access token via the connection's token manager,
+   * creating a standalone manager from the auth config if none was injected.
+   */
+  private async getOAuth2Token(
+    auth: SmtpOAuth2Auth,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    this.tokenManager ??= new OAuth2TokenManager(auth);
+    return await this.tokenManager.getAccessToken(signal);
+  }
+
+  private async authXoauth2(
+    auth: SmtpOAuth2Auth,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const token = await this.getOAuth2Token(auth, signal);
+    const initialResponse = formatXoauth2(auth.user, token);
+    const response = await this.sendCommand(
+      `AUTH XOAUTH2 ${initialResponse}`,
+      signal,
+    );
+    // On failure XOAUTH2 servers send a 334 challenge; the client replies with
+    // an empty line to receive the final failure response.
+    await this.finishOAuth2(response, "XOAUTH2", "", signal);
+  }
+
+  private async authOauthbearer(
+    auth: SmtpOAuth2Auth,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const token = await this.getOAuth2Token(auth, signal);
+    const initialResponse = formatOauthbearer(
+      auth.user,
+      token,
+      this.config.host,
+      this.config.port,
+    );
+    const response = await this.sendCommand(
+      `AUTH OAUTHBEARER ${initialResponse}`,
+      signal,
+    );
+    // RFC 7628: on failure the client replies with a single 0x01 ("AQ==") to
+    // receive the final failure response.
+    await this.finishOAuth2(response, "OAUTHBEARER", "AQ==", signal);
+  }
+
+  /**
+   * Interprets the server's reply to an OAuth SASL initial response, draining
+   * the failure challenge continuation when authentication is rejected.
+   *
+   * @throws {SmtpAuthError} If authentication did not succeed.
+   */
+  private async finishOAuth2(
+    response: SmtpResponse,
+    mechanism: string,
+    continuation: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (response.code === 235) {
+      return;
+    }
+    if (response.code === 334) {
+      const final = await this.sendCommand(continuation, signal);
+      throw new SmtpAuthError(
+        `${mechanism} authentication failed: ` +
+          `${decodeOAuth2Challenge(response.message)} (${final.message})`,
+      );
+    }
+    throw new SmtpAuthError(
+      `${mechanism} authentication failed: ${response.message}`,
+    );
   }
 
   async sendMessage(
@@ -363,17 +470,27 @@ export class SmtpConnection {
   }
 
   async quit(): Promise<void> {
-    if (!this.socket) {
+    const socket = this.socket;
+    if (!socket) {
       return;
     }
 
-    try {
-      await this.sendCommand("QUIT");
-    } catch {
-      // Ignore errors during quit
+    // Only attempt a graceful QUIT on a writable socket; a socket that never
+    // finished connecting (e.g. a refused or timed-out connection) would
+    // otherwise error or leave a dangling command timeout.
+    if (socket.writable) {
+      try {
+        await this.sendCommand("QUIT");
+      } catch {
+        // Ignore errors during quit
+      }
     }
 
-    this.socket.destroy();
+    try {
+      socket.destroy();
+    } catch {
+      // Ignore errors while tearing down the socket
+    }
     this.socket = null;
     this.authenticated = false;
     this.capabilities = [];
@@ -395,4 +512,19 @@ export interface SmtpResponse {
   readonly code: number;
   readonly message: string;
   readonly raw: string;
+}
+
+/**
+ * Decodes the Base64 JSON error challenge a server sends after a failed OAuth
+ * SASL exchange, falling back to the raw message when it is not valid Base64.
+ *
+ * @param message The challenge text from the server's 334 response.
+ * @returns A human-readable description of the failure.
+ */
+function decodeOAuth2Challenge(message: string): string {
+  try {
+    return atob(message.trim());
+  } catch {
+    return message;
+  }
 }

--- a/packages/smtp/src/smtp-connection.ts
+++ b/packages/smtp/src/smtp-connection.ts
@@ -294,7 +294,7 @@ export class SmtpConnection {
     if (
       !this.capabilities.some((cap) => cap.toUpperCase().startsWith("AUTH"))
     ) {
-      throw new Error("Server does not support authentication.");
+      throw new SmtpAuthError("Server does not support authentication.");
     }
 
     if ("accessToken" in auth || "refreshToken" in auth) {
@@ -475,10 +475,19 @@ export class SmtpConnection {
       return;
     }
     if (response.code === 334) {
-      const final = await this.sendCommand(continuation, signal);
+      let finalMessage = "";
+      try {
+        const final = await this.sendCommand(continuation, signal);
+        finalMessage = ` (${final.message})`;
+      } catch {
+        // Some servers close the connection after rejecting authentication, so
+        // sending the continuation fails; keep the decoded challenge as the
+        // error detail rather than masking it with a socket error.
+        signal?.throwIfAborted();
+      }
       throw new SmtpAuthError(
         `${mechanism} authentication failed: ` +
-          `${decodeOAuth2Challenge(response.message)} (${final.message})`,
+          `${decodeOAuth2Challenge(response.message)}${finalMessage}`,
       );
     }
     throw new SmtpAuthError(

--- a/packages/smtp/src/smtp-connection.ts
+++ b/packages/smtp/src/smtp-connection.ts
@@ -25,6 +25,20 @@ const MAX_COMMAND_LINE_LENGTH = 512;
 /** The length of the CRLF terminator appended to every command. */
 const CRLF_LENGTH = 2;
 
+/**
+ * Whether a host refers to the local loopback interface, for which cleartext
+ * OAuth 2.0 authentication is permitted (e.g. local testing and development).
+ *
+ * @param host The host to check.
+ * @returns `true` if the host is a loopback address.
+ */
+function isLoopbackHost(host: string): boolean {
+  return host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]";
+}
+
 export class SmtpConnection {
   socket: Socket | TLSSocket | null = null;
   config: ResolvedSmtpConfig;
@@ -284,6 +298,19 @@ export class SmtpConnection {
     }
 
     if ("accessToken" in auth || "refreshToken" in auth) {
+      // OAuth 2.0 access tokens are bearer credentials, so refuse to send them
+      // over a cleartext connection.  Loopback hosts are excepted for local
+      // testing and development.
+      if (
+        !(this.socket instanceof TLSSocket) &&
+        !isLoopbackHost(this.config.host)
+      ) {
+        throw new SmtpAuthError(
+          "OAuth 2.0 authentication requires a TLS-secured connection to " +
+            "protect the access token; use `secure: true` or STARTTLS.",
+        );
+      }
+
       const mechanism = auth.method ?? selectOAuth2Mechanism(this.capabilities);
       switch (mechanism) {
         case "xoauth2":

--- a/packages/smtp/src/smtp-connection.ts
+++ b/packages/smtp/src/smtp-connection.ts
@@ -568,15 +568,21 @@ export class SmtpConnection {
       // by QUIT_TIMEOUT_MS) rather than for the server's reply, so an
       // unresponsive server cannot block teardown for the full socket timeout.
       await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, QUIT_TIMEOUT_MS);
-        try {
-          socket.write("QUIT\r\n", () => {
-            clearTimeout(timer);
-            resolve();
-          });
-        } catch {
+        const done = () => {
           clearTimeout(timer);
+          socket.off("error", done);
+          socket.off("close", done);
           resolve();
+        };
+        const timer = setTimeout(done, QUIT_TIMEOUT_MS);
+        // Teardown is best-effort: an asynchronous socket error or close must
+        // not surface as an unhandled error event, so settle on those too.
+        socket.once("error", done);
+        socket.once("close", done);
+        try {
+          socket.write("QUIT\r\n", done);
+        } catch {
+          done();
         }
       });
     }

--- a/packages/smtp/src/smtp-connection.ts
+++ b/packages/smtp/src/smtp-connection.ts
@@ -613,12 +613,17 @@ export interface SmtpResponse {
  * Decodes the Base64 JSON error challenge a server sends after a failed OAuth
  * SASL exchange, falling back to the raw message when it is not valid Base64.
  *
+ * The bytes are decoded as UTF-8 (via `TextDecoder`) so non-ASCII challenge
+ * messages are not corrupted, unlike decoding `atob`'s Latin-1 output directly.
+ *
  * @param message The challenge text from the server's 334 response.
  * @returns A human-readable description of the failure.
  */
 function decodeOAuth2Challenge(message: string): string {
   try {
-    return atob(message.trim());
+    const binary = atob(message.trim());
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
   } catch {
     return message;
   }

--- a/packages/smtp/src/smtp-transport.integration.test.ts
+++ b/packages/smtp/src/smtp-transport.integration.test.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@upyo/core";
+import type { Message, Receipt } from "@upyo/core";
 import { SmtpTransport } from "@upyo/smtp";
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
@@ -47,6 +47,42 @@ describe("SmtpTransport Integration Tests", () => {
       ...overrides,
     };
   }
+
+  test("should reject sendMany when aborted after sending has started", async () => {
+    const { server, transport } = await setupTest();
+    try {
+      const controller = new AbortController();
+
+      const messages = async function* () {
+        yield createTestMessage();
+        yield createTestMessage();
+      };
+
+      const receipts: Receipt[] = [];
+      await assert.rejects(
+        (async () => {
+          for await (
+            const receipt of transport.sendMany(messages(), {
+              signal: controller.signal,
+            })
+          ) {
+            receipts.push(receipt);
+            // Cancel once the first message has been delivered.
+            controller.abort();
+          }
+        })(),
+        (error: unknown) =>
+          error instanceof DOMException && error.name === "AbortError",
+      );
+
+      // The first message succeeded; cancellation then rejected rather than
+      // yielding a failed receipt.
+      assert.equal(receipts.length, 1);
+      assert.ok(receipts[0].successful);
+    } finally {
+      await teardownTest(server, transport);
+    }
+  });
 
   test("should send a basic email successfully", async () => {
     const { server, transport } = await setupTest();

--- a/packages/smtp/src/smtp-transport.oauth2.e2e.test.ts
+++ b/packages/smtp/src/smtp-transport.oauth2.e2e.test.ts
@@ -33,8 +33,12 @@ describe(
       }
     });
 
-    test("reuses a cached token across multiple sends", async () => {
-      const { smtp, from, to } = getOAuth2TestConfig();
+    test("reuses a cached token across multiple sends", async (t) => {
+      const { smtp, from, to, usesRefreshFlow } = getOAuth2TestConfig();
+      if (!usesRefreshFlow) {
+        t.skip("requires refresh-token auth to exercise token caching");
+        return;
+      }
       const transport = new SmtpTransport(smtp);
       try {
         const first = await transport.send(

--- a/packages/smtp/src/smtp-transport.oauth2.e2e.test.ts
+++ b/packages/smtp/src/smtp-transport.oauth2.e2e.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { SmtpTransport } from "./smtp-transport.ts";
+import {
+  createTestMessage,
+  getOAuth2TestConfig,
+  isOAuth2TestingEnabled,
+} from "./test-utils/test-config.ts";
+
+// These tests run against a real OAuth 2.0-enabled SMTP server (e.g. Gmail or
+// Outlook).  They are skipped unless the SMTP_OAUTH2_* environment variables
+// are configured.  See packages/smtp/README.md for the required variables and
+// how to mint a token with google-auth-library / msal-node.
+describe(
+  "SmtpTransport OAuth 2.0 E2E",
+  { skip: !isOAuth2TestingEnabled() },
+  () => {
+    if (!isOAuth2TestingEnabled()) return;
+
+    test("sends a real message authenticated via OAuth 2.0", async () => {
+      const { smtp, from, to } = getOAuth2TestConfig();
+      const transport = new SmtpTransport(smtp);
+      try {
+        const receipt = await transport.send(
+          createTestMessage({ senderEmail: from, recipientEmail: to }),
+        );
+        assert.ok(
+          receipt.successful,
+          receipt.successful ? undefined : receipt.errorMessages.join("; "),
+        );
+      } finally {
+        await transport.closeAllConnections();
+      }
+    });
+
+    test("reuses a cached token across multiple sends", async () => {
+      const { smtp, from, to } = getOAuth2TestConfig();
+      const transport = new SmtpTransport(smtp);
+      try {
+        const first = await transport.send(
+          createTestMessage({ senderEmail: from, recipientEmail: to }),
+        );
+        const second = await transport.send(
+          createTestMessage({ senderEmail: from, recipientEmail: to }),
+        );
+        assert.ok(first.successful);
+        assert.ok(second.successful);
+      } finally {
+        await transport.closeAllConnections();
+      }
+    });
+  },
+);

--- a/packages/smtp/src/smtp-transport.oauth2.integration.test.ts
+++ b/packages/smtp/src/smtp-transport.oauth2.integration.test.ts
@@ -69,17 +69,20 @@ describe("SmtpTransport OAuth 2.0 integration", () => {
       );
     }) as typeof fetch;
 
-    // Pooling disabled so each send uses a fresh connection that authenticates
-    // independently; the shared token manager must still refresh only once.
-    const { server, transport } = await setup({
-      user: "user@example.com",
-      clientId: "client-id",
-      clientSecret: "client-secret",
-      refreshToken: "refresh-token",
-      tokenEndpoint: "https://oauth2.example.com/token",
-    }, { pool: false });
-
+    let server: MockSmtpServer | undefined;
+    let transport: SmtpTransport | undefined;
     try {
+      // Pooling disabled so each send uses a fresh connection that
+      // authenticates independently; the shared token manager must still
+      // refresh only once.
+      ({ server, transport } = await setup({
+        user: "user@example.com",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+        tokenEndpoint: "https://oauth2.example.com/token",
+      }, { pool: false }));
+
       const first = await transport.send(createTestMessage());
       const second = await transport.send(createTestMessage());
       assert.ok(first.successful);
@@ -91,8 +94,8 @@ describe("SmtpTransport OAuth 2.0 integration", () => {
       );
     } finally {
       globalThis.fetch = originalFetch;
-      await transport.closeAllConnections();
-      await server.stop();
+      await transport?.closeAllConnections();
+      await server?.stop();
     }
   });
 

--- a/packages/smtp/src/smtp-transport.oauth2.integration.test.ts
+++ b/packages/smtp/src/smtp-transport.oauth2.integration.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { SmtpConfig } from "./config.ts";
+import { SmtpTransport } from "./smtp-transport.ts";
+import { MockSmtpServer } from "./test-utils/mock-smtp-server.ts";
+import { createTestMessage } from "./test-utils/test-config.ts";
+
+describe("SmtpTransport OAuth 2.0 integration", () => {
+  async function setup(
+    auth: SmtpConfig["auth"],
+    overrides: Partial<SmtpConfig> = {},
+  ) {
+    const server = new MockSmtpServer();
+    await server.start();
+    const transport = new SmtpTransport({
+      host: "localhost",
+      port: server.getPort(),
+      secure: false,
+      connectionTimeout: 5000,
+      socketTimeout: 5000,
+      auth,
+      ...overrides,
+    });
+    return { server, transport };
+  }
+
+  test("sends a message authenticated with a static XOAUTH2 token", async () => {
+    const { server, transport } = await setup({
+      user: "user@example.com",
+      accessToken: "the-access-token",
+    });
+    try {
+      const receipt = await transport.send(createTestMessage());
+      assert.ok(receipt.successful);
+      assert.equal(server.getReceivedMessages().length, 1);
+      assert.ok(server.getLastAuthCommand()?.startsWith("AUTH XOAUTH2 "));
+    } finally {
+      await transport.closeAllConnections();
+      await server.stop();
+    }
+  });
+
+  test("sends a message authenticated with OAUTHBEARER", async () => {
+    const { server, transport } = await setup({
+      user: "user@example.com",
+      accessToken: "the-access-token",
+      method: "oauthbearer",
+    });
+    try {
+      const receipt = await transport.send(createTestMessage());
+      assert.ok(receipt.successful);
+      assert.ok(server.getLastAuthCommand()?.startsWith("AUTH OAUTHBEARER "));
+    } finally {
+      await transport.closeAllConnections();
+      await server.stop();
+    }
+  });
+
+  test("shares one refreshed access token across connections", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = ((_input: RequestInfo | URL, _init?: RequestInit) => {
+      fetchCalls++;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: "refreshed", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as typeof fetch;
+
+    // Pooling disabled so each send uses a fresh connection that authenticates
+    // independently; the shared token manager must still refresh only once.
+    const { server, transport } = await setup({
+      user: "user@example.com",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      refreshToken: "refresh-token",
+      tokenEndpoint: "https://oauth2.example.com/token",
+    }, { pool: false });
+
+    try {
+      const first = await transport.send(createTestMessage());
+      const second = await transport.send(createTestMessage());
+      assert.ok(first.successful);
+      assert.ok(second.successful);
+      assert.equal(
+        fetchCalls,
+        1,
+        "the refresh token is exchanged once and cached across connections",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      await transport.closeAllConnections();
+      await server.stop();
+    }
+  });
+
+  test("reports a failed receipt when OAuth authentication is rejected", async () => {
+    // Authentication happens while establishing the connection; like other SMTP
+    // setup failures, a rejected token yields a failed receipt rather than
+    // throwing.
+    const { server, transport } = await setup({
+      user: "user@example.com",
+      accessToken: "bad-token",
+    });
+    server.setResponse("AUTH", { code: 535, message: "5.7.8 Bad credentials" });
+    try {
+      const receipt = await transport.send(createTestMessage());
+      assert.ok(!receipt.successful);
+      if (!receipt.successful) {
+        assert.ok(receipt.errorMessages.some((m) => /XOAUTH2/.test(m)));
+      }
+    } finally {
+      await transport.closeAllConnections();
+      await server.stop();
+    }
+  });
+});

--- a/packages/smtp/src/smtp-transport.test.ts
+++ b/packages/smtp/src/smtp-transport.test.ts
@@ -39,17 +39,13 @@ describe("SmtpTransport", () => {
       headers: new Headers(),
     };
 
-    // This will fail without a real SMTP server, but we can test the structure
-    try {
-      const receipt = await transport.send(message);
-      // If we got here, the message was successfully sent
-      assert.strictEqual(receipt.successful, true);
-      if (receipt.successful) {
-        assert.strictEqual(receipt.messageId.length > 0, true);
-      }
-    } catch (error) {
-      // Expected to fail without a real SMTP server
-      assert.strictEqual(error instanceof Error, true);
+    // send() returns a receipt (success or failure) without throwing, even when
+    // no SMTP server is listening, so assert the receipt shape either way.
+    const receipt = await transport.send(message);
+    if (receipt.successful) {
+      assert.ok(receipt.messageId.length > 0);
+    } else {
+      assert.ok(receipt.errorMessages.length > 0);
     }
   });
 

--- a/packages/smtp/src/smtp-transport.test.ts
+++ b/packages/smtp/src/smtp-transport.test.ts
@@ -233,17 +233,18 @@ describe("SmtpTransport", () => {
         headers: new Headers(),
       };
 
-      try {
-        await transport.send(message);
-        assert.fail("Expected timeout error");
-      } catch (error) {
-        assert.ok(error instanceof Error);
-        // Should be some form of connection error or timeout
+      const receipt = await transport.send(message);
+
+      // Connection setup failures are reported as a failed receipt.
+      assert.ok(!receipt.successful);
+      if (!receipt.successful) {
         assert.ok(
-          error.message.includes("timeout") ||
-            error.message.includes("connect") ||
-            error.message.includes("ECONNREFUSED") ||
-            error.message.includes("EHOSTUNREACH"),
+          receipt.errorMessages.some((m) =>
+            m.includes("timeout") ||
+            m.includes("connect") ||
+            m.includes("ECONNREFUSED") ||
+            m.includes("EHOSTUNREACH")
+          ),
         );
       }
     });
@@ -270,17 +271,18 @@ describe("SmtpTransport", () => {
         headers: new Headers(),
       };
 
-      try {
-        await transport.send(message);
-        assert.fail("Expected DNS resolution error");
-      } catch (error) {
-        assert.ok(error instanceof Error);
-        // Should be DNS resolution error or connection error
+      const receipt = await transport.send(message);
+
+      // Connection setup failures are reported as a failed receipt.
+      assert.ok(!receipt.successful);
+      if (!receipt.successful) {
         assert.ok(
-          error.message.includes("ENOTFOUND") ||
-            error.message.includes("getaddrinfo") ||
-            error.message.includes("connect") ||
-            error.message.includes("host"),
+          receipt.errorMessages.some((m) =>
+            m.includes("ENOTFOUND") ||
+            m.includes("getaddrinfo") ||
+            m.includes("connect") ||
+            m.includes("host")
+          ),
         );
       }
     });
@@ -307,16 +309,17 @@ describe("SmtpTransport", () => {
         headers: new Headers(),
       };
 
-      try {
-        await transport.send(message);
-        assert.fail("Expected connection refused error");
-      } catch (error) {
-        assert.ok(error instanceof Error);
-        // Should be connection refused error
+      const receipt = await transport.send(message);
+
+      // Connection setup failures are reported as a failed receipt.
+      assert.ok(!receipt.successful);
+      if (!receipt.successful) {
         assert.ok(
-          error.message.includes("ECONNREFUSED") ||
-            error.message.includes("connect") ||
-            error.message.includes("refused"),
+          receipt.errorMessages.some((m) =>
+            m.includes("ECONNREFUSED") ||
+            m.includes("connect") ||
+            m.includes("refused")
+          ),
         );
       }
     });
@@ -399,13 +402,10 @@ describe("SmtpTransport", () => {
         headers: new Headers(),
       };
 
-      try {
-        await transport.send(noRecipientsMessage);
-        assert.fail("Expected error for empty recipients");
-      } catch (error) {
-        assert.ok(error instanceof Error);
-        // Should be validation error about recipients
-      }
+      // Sending with no recipients (or no reachable server) yields a failed
+      // receipt rather than throwing.
+      const receipt = await transport.send(noRecipientsMessage);
+      assert.ok(!receipt.successful);
     });
 
     test("should handle connection errors during sendMany", async () => {
@@ -432,24 +432,18 @@ describe("SmtpTransport", () => {
       }));
 
       const receipts = [];
-      let errorCount = 0;
-
-      try {
-        for await (const receipt of transport.sendMany(messages)) {
-          if (receipt.successful) {
-            receipts.push(receipt);
-          } else {
-            errorCount++;
-          }
-        }
-      } catch (error) {
-        // Expected to fail with connection errors
-        assert.ok(error instanceof Error);
-        errorCount++;
+      for await (const receipt of transport.sendMany(messages)) {
+        receipts.push(receipt);
       }
 
-      // Should have attempted to process messages and encountered errors
-      assert.ok(errorCount > 0 || receipts.length >= 0);
+      // Connection setup failure yields a failed receipt for every message.
+      assert.strictEqual(receipts.length, 3);
+      receipts.forEach((receipt) => {
+        assert.ok(!receipt.successful);
+        if (!receipt.successful) {
+          assert.ok(receipt.errorMessages.length > 0);
+        }
+      });
     });
 
     test("should handle resource cleanup after errors", async () => {
@@ -521,19 +515,18 @@ describe("SmtpTransport", () => {
       // Try multiple concurrent sends that should all fail
       const promises = Array.from(
         { length: 5 },
-        () =>
-          transport.send(message).catch((error) => {
-            assert.ok(error instanceof Error);
-            return error;
-          }),
+        () => transport.send(message),
       );
 
       const results = await Promise.all(promises);
 
-      // All should have resulted in errors
+      // All should have resulted in failed receipts
       assert.strictEqual(results.length, 5);
       results.forEach((result) => {
-        assert.ok(result instanceof Error);
+        assert.ok(!result.successful);
+        if (!result.successful) {
+          assert.ok(result.errorMessages.length > 0);
+        }
       });
     });
   });

--- a/packages/smtp/src/smtp-transport.ts
+++ b/packages/smtp/src/smtp-transport.ts
@@ -1,6 +1,7 @@
 import type { Message, Receipt, Transport, TransportOptions } from "@upyo/core";
 import type { SmtpConfig } from "./config.ts";
 import { SmtpConnection } from "./smtp-connection.ts";
+import { OAuth2TokenManager } from "./oauth2.ts";
 import { convertMessage } from "./message-converter.ts";
 
 /**
@@ -50,6 +51,14 @@ export class SmtpTransport implements Transport, AsyncDisposable {
   private connectionPool: SmtpConnection[] = [];
 
   /**
+   * A token manager shared across all pooled connections, present only when the
+   * configured authentication uses OAuth 2.0.  Sharing it ensures the
+   * refresh-token exchange happens at most once per token lifetime instead of
+   * once per connection.
+   */
+  private readonly tokenManager: OAuth2TokenManager | undefined;
+
+  /**
    * Creates a new SMTP transport instance.
    *
    * @param config SMTP configuration including server details, authentication,
@@ -58,6 +67,11 @@ export class SmtpTransport implements Transport, AsyncDisposable {
   constructor(config: SmtpConfig) {
     this.config = config;
     this.poolSize = config.poolSize ?? 5;
+    const auth = config.auth;
+    this.tokenManager =
+      auth != null && ("accessToken" in auth || "refreshToken" in auth)
+        ? new OAuth2TokenManager(auth)
+        : undefined;
   }
 
   /**
@@ -89,9 +103,16 @@ export class SmtpTransport implements Transport, AsyncDisposable {
   async send(message: Message, options?: TransportOptions): Promise<Receipt> {
     options?.signal?.throwIfAborted();
 
-    const connection = await this.getConnection(options?.signal);
+    let connection: SmtpConnection | undefined;
 
     try {
+      // Establishing the connection—including authentication, e.g. acquiring an
+      // OAuth 2.0 access token—is part of delivery, so setup failures are
+      // reported as a failed receipt rather than thrown.  (Cancellation via the
+      // abort signal still rejects: an already-aborted signal is caught by the
+      // guard above, before this method does any work.)
+      connection = await this.getConnection(options?.signal);
+
       options?.signal?.throwIfAborted();
 
       const smtpMessage = await convertMessage(message, this.config.dkim);
@@ -110,7 +131,12 @@ export class SmtpTransport implements Transport, AsyncDisposable {
         messageId,
       };
     } catch (error) {
-      await this.discardConnection(connection);
+      if (connection != null) {
+        await this.discardConnection(connection);
+      }
+
+      // Cancellation rejects rather than producing a receipt.
+      options?.signal?.throwIfAborted();
 
       return {
         successful: false,
@@ -153,7 +179,29 @@ export class SmtpTransport implements Transport, AsyncDisposable {
   ): AsyncIterable<Receipt> {
     options?.signal?.throwIfAborted();
 
-    const connection = await this.getConnection(options?.signal);
+    let connection: SmtpConnection;
+    try {
+      connection = await this.getConnection(options?.signal);
+    } catch (error) {
+      // Cancellation rejects rather than producing receipts.
+      options?.signal?.throwIfAborted();
+
+      // Connection setup (including authentication) failed, so no message can
+      // be delivered.  Report a failed receipt for each message rather than
+      // throwing.
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
+      for await (const _ of messages) {
+        options?.signal?.throwIfAborted();
+        yield {
+          successful: false,
+          errorMessages: [errorMessage],
+        };
+      }
+      return;
+    }
+
     let connectionValid = true;
 
     try {
@@ -185,6 +233,9 @@ export class SmtpTransport implements Transport, AsyncDisposable {
               messageId,
             };
           } catch (error) {
+            // Cancellation rejects rather than producing a receipt.
+            options?.signal?.throwIfAborted();
+
             // Mark connection as invalid on any error
             connectionValid = false;
 
@@ -222,6 +273,9 @@ export class SmtpTransport implements Transport, AsyncDisposable {
               messageId,
             };
           } catch (error) {
+            // Cancellation rejects rather than producing a receipt.
+            options?.signal?.throwIfAborted();
+
             // Mark connection as invalid on any error
             connectionValid = false;
 
@@ -257,8 +311,15 @@ export class SmtpTransport implements Transport, AsyncDisposable {
     }
 
     // Create a new connection
-    const connection = new SmtpConnection(this.config);
-    await this.connectAndSetup(connection, signal);
+    const connection = new SmtpConnection(this.config, this.tokenManager);
+    try {
+      await this.connectAndSetup(connection, signal);
+    } catch (error) {
+      // Setup failed after the socket may have opened (e.g. EHLO, STARTTLS, or
+      // authentication failure); discard it so it does not leak.
+      await this.discardConnection(connection);
+      throw error;
+    }
     return connection;
   }
 

--- a/packages/smtp/src/test-utils/mock-smtp-server.ts
+++ b/packages/smtp/src/test-utils/mock-smtp-server.ts
@@ -124,11 +124,17 @@ export class MockSmtpServer extends EventEmitter {
             continue;
           }
 
-          // Drain the OAuth SASL failure continuation (which may be an empty
-          // line for XOAUTH2) before the empty-line skip below.
+          // Validate and drain the OAuth SASL failure continuation (an empty
+          // line for XOAUTH2, "AQ==" for OAUTHBEARER) before the empty-line skip
+          // below, so a wrong continuation is rejected instead of masked.
           if (awaitingOAuthFailure != null) {
-            const authResponse = this.responses.get("AUTH")!;
-            socket.write(`${authResponse.code} ${authResponse.message}\r\n`);
+            const expected = awaitingOAuthFailure === "xoauth2" ? "" : "AQ==";
+            if (line === expected) {
+              const authResponse = this.responses.get("AUTH")!;
+              socket.write(`${authResponse.code} ${authResponse.message}\r\n`);
+            } else {
+              socket.write("501 Invalid OAuth continuation\r\n");
+            }
             awaitingOAuthFailure = null;
             continue;
           }

--- a/packages/smtp/src/test-utils/mock-smtp-server.ts
+++ b/packages/smtp/src/test-utils/mock-smtp-server.ts
@@ -8,6 +8,7 @@ export class MockSmtpServer extends EventEmitter {
   private responses: Map<string, SmtpResponse> = new Map();
   private receivedMessages: MockSmtpMessage[] = [];
   private timeouts: Set<number | NodeJS.Timeout> = new Set();
+  private lastAuthCommand: string | null = null;
 
   constructor(port: number = 0) {
     super();
@@ -67,6 +68,11 @@ export class MockSmtpServer extends EventEmitter {
       let buffer = "";
       let inDataMode = false;
       let currentMessage: Partial<MockSmtpMessage> = {};
+      // When set, the server has sent a SASL failure challenge (334) for an
+      // OAuth mechanism and is awaiting the client's continuation line (an
+      // empty line for XOAUTH2, or "AQ==" for OAUTHBEARER) before sending the
+      // final failure reply.
+      let awaitingOAuthFailure: "xoauth2" | "oauthbearer" | null = null;
 
       socket.on("data", (data) => {
         buffer += data.toString();
@@ -95,6 +101,15 @@ export class MockSmtpServer extends EventEmitter {
         buffer = lines.pop() || "";
 
         for (const line of lines) {
+          // Drain the OAuth SASL failure continuation (which may be an empty
+          // line for XOAUTH2) before the empty-line skip below.
+          if (awaitingOAuthFailure != null) {
+            const authResponse = this.responses.get("AUTH")!;
+            socket.write(`${authResponse.code} ${authResponse.message}\r\n`);
+            awaitingOAuthFailure = null;
+            continue;
+          }
+
           if (!line.trim()) continue;
 
           const command = line.split(" ")[0].toUpperCase();
@@ -105,7 +120,7 @@ export class MockSmtpServer extends EventEmitter {
             case "HELO":
               const ehloResponse = this.responses.get("EHLO")!;
               socket.write(`${ehloResponse.code}-${ehloResponse.message}\r\n`);
-              socket.write("250-AUTH PLAIN LOGIN\r\n");
+              socket.write("250-AUTH PLAIN LOGIN XOAUTH2 OAUTHBEARER\r\n");
               // Note: STARTTLS removed from default capabilities
               // Mock server doesn't actually perform TLS upgrade
               // Tests can manually send STARTTLS command if needed
@@ -113,7 +128,22 @@ export class MockSmtpServer extends EventEmitter {
               break;
 
             case "AUTH":
-              if (line.includes("PLAIN")) {
+              this.lastAuthCommand = line;
+              if (line.includes("XOAUTH2") || line.includes("OAUTHBEARER")) {
+                const authResponse = this.responses.get("AUTH")!;
+                if (authResponse.code === 235) {
+                  socket.write(
+                    `${authResponse.code} ${authResponse.message}\r\n`,
+                  );
+                } else {
+                  // Send a base64-encoded JSON error challenge and await the
+                  // client's continuation line before the final failure reply.
+                  socket.write("334 eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIn0=\r\n");
+                  awaitingOAuthFailure = line.includes("XOAUTH2")
+                    ? "xoauth2"
+                    : "oauthbearer";
+                }
+              } else if (line.includes("PLAIN")) {
                 const authResponse = this.responses.get("AUTH")!;
                 socket.write(
                   `${authResponse.code} ${authResponse.message}\r\n`,
@@ -253,6 +283,10 @@ export class MockSmtpServer extends EventEmitter {
 
   getReceivedMessages(): MockSmtpMessage[] {
     return [...this.receivedMessages];
+  }
+
+  getLastAuthCommand(): string | null {
+    return this.lastAuthCommand;
   }
 
   clearReceivedMessages(): void {

--- a/packages/smtp/src/test-utils/mock-smtp-server.ts
+++ b/packages/smtp/src/test-utils/mock-smtp-server.ts
@@ -73,6 +73,21 @@ export class MockSmtpServer extends EventEmitter {
       // empty line for XOAUTH2, or "AQ==" for OAUTHBEARER) before sending the
       // final failure reply.
       let awaitingOAuthFailure: "xoauth2" | "oauthbearer" | null = null;
+      // When set, the client used the two-step SASL form (`AUTH <mech>` without
+      // an inline initial response) and the next line is that initial response.
+      let awaitingSaslInitialResponse: "xoauth2" | "oauthbearer" | null = null;
+
+      // Replies to an OAuth SASL initial response: success (235) or a 334
+      // failure challenge that awaits the client's continuation line.
+      const respondToOAuth = (mechanism: "xoauth2" | "oauthbearer") => {
+        const authResponse = this.responses.get("AUTH")!;
+        if (authResponse.code === 235) {
+          socket.write(`${authResponse.code} ${authResponse.message}\r\n`);
+        } else {
+          socket.write("334 eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIn0=\r\n");
+          awaitingOAuthFailure = mechanism;
+        }
+      };
 
       socket.on("data", (data) => {
         buffer += data.toString();
@@ -101,6 +116,14 @@ export class MockSmtpServer extends EventEmitter {
         buffer = lines.pop() || "";
 
         for (const line of lines) {
+          // Consume the two-step SASL initial response sent on its own line.
+          if (awaitingSaslInitialResponse != null) {
+            const mechanism = awaitingSaslInitialResponse;
+            awaitingSaslInitialResponse = null;
+            respondToOAuth(mechanism);
+            continue;
+          }
+
           // Drain the OAuth SASL failure continuation (which may be an empty
           // line for XOAUTH2) before the empty-line skip below.
           if (awaitingOAuthFailure != null) {
@@ -127,21 +150,21 @@ export class MockSmtpServer extends EventEmitter {
               socket.write("250 HELP\r\n");
               break;
 
-            case "AUTH":
+            case "AUTH": {
               this.lastAuthCommand = line;
-              if (line.includes("XOAUTH2") || line.includes("OAUTHBEARER")) {
-                const authResponse = this.responses.get("AUTH")!;
-                if (authResponse.code === 235) {
-                  socket.write(
-                    `${authResponse.code} ${authResponse.message}\r\n`,
-                  );
+              const parts = line.split(" ");
+              const mechanism = parts[1]?.toUpperCase();
+              if (mechanism === "XOAUTH2" || mechanism === "OAUTHBEARER") {
+                const mech = mechanism === "XOAUTH2"
+                  ? "xoauth2"
+                  : "oauthbearer";
+                if (parts.length >= 3) {
+                  respondToOAuth(mech);
                 } else {
-                  // Send a base64-encoded JSON error challenge and await the
-                  // client's continuation line before the final failure reply.
-                  socket.write("334 eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIn0=\r\n");
-                  awaitingOAuthFailure = line.includes("XOAUTH2")
-                    ? "xoauth2"
-                    : "oauthbearer";
+                  // Two-step form: the client omitted the initial response, so
+                  // request it with an empty 334 challenge.
+                  socket.write("334 \r\n");
+                  awaitingSaslInitialResponse = mech;
                 }
               } else if (line.includes("PLAIN")) {
                 const authResponse = this.responses.get("AUTH")!;
@@ -155,8 +178,9 @@ export class MockSmtpServer extends EventEmitter {
                 socket.write("334 Continue\r\n");
               }
               break;
+            }
 
-              // deno-lint-ignore no-case-declarations
+            // deno-lint-ignore no-case-declarations
             case "MAIL":
               currentMessage.from = this.extractEmail(line);
               const mailResponse = this.responses.get("MAIL")!;

--- a/packages/smtp/src/test-utils/test-config.ts
+++ b/packages/smtp/src/test-utils/test-config.ts
@@ -7,7 +7,7 @@ import type {
 } from "@upyo/core";
 import { isEmailAddress } from "@upyo/core";
 import process from "node:process";
-import type { SmtpConfig } from "../config.ts";
+import type { SmtpAuth, SmtpConfig } from "../config.ts";
 import type { MailpitConfig } from "./mailpit-client.ts";
 
 export interface TestEnvironmentConfig {
@@ -39,6 +39,84 @@ export function getTestConfig(): TestEnvironmentConfig {
 
 export function isMailpitTestingEnabled(): boolean {
   return !!process.env.MAILPIT_API_URL || !!process.env.MAILPIT_SMTP_HOST;
+}
+
+export interface OAuth2TestConfig {
+  smtp: SmtpConfig;
+  from: string;
+  to: string;
+  usesRefreshFlow: boolean;
+}
+
+/**
+ * Whether the OAuth 2.0 end-to-end tests are configured to run.
+ *
+ * Requires a host, a user, and a token source: either a static access token
+ * (`SMTP_OAUTH2_ACCESS_TOKEN`) or the refresh-token trio
+ * (`SMTP_OAUTH2_REFRESH_TOKEN`, `SMTP_OAUTH2_CLIENT_ID`,
+ * `SMTP_OAUTH2_TOKEN_ENDPOINT`).
+ */
+export function isOAuth2TestingEnabled(): boolean {
+  const hasTokenSource = !!process.env.SMTP_OAUTH2_ACCESS_TOKEN ||
+    (!!process.env.SMTP_OAUTH2_REFRESH_TOKEN &&
+      !!process.env.SMTP_OAUTH2_CLIENT_ID &&
+      !!process.env.SMTP_OAUTH2_TOKEN_ENDPOINT);
+  return !!process.env.SMTP_OAUTH2_HOST && !!process.env.SMTP_OAUTH2_USER &&
+    hasTokenSource;
+}
+
+/**
+ * Builds the OAuth 2.0 SMTP test configuration from environment variables.
+ *
+ * @throws {Error} If OAuth 2.0 testing is not enabled.
+ */
+export function getOAuth2TestConfig(): OAuth2TestConfig {
+  if (!isOAuth2TestingEnabled()) {
+    throw new Error(
+      "OAuth 2.0 testing is not enabled. Set SMTP_OAUTH2_HOST, " +
+        "SMTP_OAUTH2_USER, and a token source (SMTP_OAUTH2_ACCESS_TOKEN, or " +
+        "the SMTP_OAUTH2_REFRESH_TOKEN/SMTP_OAUTH2_CLIENT_ID/" +
+        "SMTP_OAUTH2_TOKEN_ENDPOINT trio).",
+    );
+  }
+
+  const user = process.env.SMTP_OAUTH2_USER!;
+  const mechanism = process.env.SMTP_OAUTH2_MECHANISM;
+  const method = mechanism === "oauthbearer"
+    ? "oauthbearer"
+    : mechanism === "xoauth2"
+    ? "xoauth2"
+    : undefined;
+
+  const accessToken = process.env.SMTP_OAUTH2_ACCESS_TOKEN;
+  const usesRefreshFlow = accessToken == null;
+  const auth: SmtpAuth = usesRefreshFlow
+    ? {
+      user,
+      clientId: process.env.SMTP_OAUTH2_CLIENT_ID!,
+      clientSecret: process.env.SMTP_OAUTH2_CLIENT_SECRET,
+      refreshToken: process.env.SMTP_OAUTH2_REFRESH_TOKEN!,
+      tokenEndpoint: process.env.SMTP_OAUTH2_TOKEN_ENDPOINT!,
+      scope: process.env.SMTP_OAUTH2_SCOPE,
+      method,
+    }
+    : {
+      user,
+      accessToken,
+      method,
+    };
+
+  return {
+    smtp: {
+      host: process.env.SMTP_OAUTH2_HOST!,
+      port: parseInt(process.env.SMTP_OAUTH2_PORT ?? "587", 10),
+      secure: process.env.SMTP_OAUTH2_SECURE === "true",
+      auth,
+    },
+    from: process.env.SMTP_OAUTH2_FROM ?? user,
+    to: process.env.SMTP_OAUTH2_TO ?? user,
+    usesRefreshFlow,
+  };
 }
 
 export function createTestMessage(

--- a/packages/smtp/src/test-utils/test-config.ts
+++ b/packages/smtp/src/test-utils/test-config.ts
@@ -88,21 +88,23 @@ export function getOAuth2TestConfig(): OAuth2TestConfig {
     ? "xoauth2"
     : undefined;
 
+  // An empty SMTP_OAUTH2_ACCESS_TOKEN is treated as "not set" (matching
+  // isOAuth2TestingEnabled), so the refresh-token flow is used in that case.
   const accessToken = process.env.SMTP_OAUTH2_ACCESS_TOKEN;
-  const usesRefreshFlow = accessToken == null;
-  const auth: SmtpAuth = usesRefreshFlow
+  const usesRefreshFlow = !accessToken;
+  const auth: SmtpAuth = accessToken
     ? {
+      user,
+      accessToken,
+      method,
+    }
+    : {
       user,
       clientId: process.env.SMTP_OAUTH2_CLIENT_ID!,
       clientSecret: process.env.SMTP_OAUTH2_CLIENT_SECRET,
       refreshToken: process.env.SMTP_OAUTH2_REFRESH_TOKEN!,
       tokenEndpoint: process.env.SMTP_OAUTH2_TOKEN_ENDPOINT!,
       scope: process.env.SMTP_OAUTH2_SCOPE,
-      method,
-    }
-    : {
-      user,
-      accessToken,
       method,
     };
 


### PR DESCRIPTION
## Summary

Resolves #19.  Adds OAuth 2.0 authentication to `@upyo/smtp` via the SASL *XOAUTH2* and *OAUTHBEARER* ([RFC 7628](https://www.rfc-editor.org/rfc/rfc7628)) mechanisms, so the transport can authenticate with providers like Gmail and Outlook that require OAuth 2.0 instead of passwords.

Three ways to supply a token:

- a static access token string;
- a callback (`OAuth2TokenProvider`) invoked per connection — plug in `google-auth-library` / `msal-node` for transparent refresh;
- a built-in `refresh_token` grant flow (`clientId`/`refreshToken`/`tokenEndpoint`) that fetches and caches tokens itself, coalescing concurrent refreshes and sharing the cache across pooled connections.

`SmtpAuth` becomes a discriminated union (`SmtpUserPassAuth | SmtpOAuth2TokenAuth | SmtpOAuth2RefreshAuth`); existing `{ user, pass }` configs keep working.  Token endpoints must use HTTPS (loopback HTTP allowed for testing).

## Behavior change

`SmtpTransport.send()` and `sendMany()` now report connection/authentication setup failures as a failed `Receipt` instead of throwing, consistent with message-level failures.  Cancellation via `AbortSignal` still rejects.  Half-open connections from a failed setup are now discarded.  Documented in *CHANGES.md*.

## Verification

- `deno task check` (type / lint / format / hongdown / dry-run publish)
- Deno / Node / Bun unit + mock-integration suites (env-gated real-provider E2E skipped)
- `cd docs && pnpm build` (Twoslash)
