### PR TITLE
Retry transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ functions.  It's structured as a monorepo with multiple packages:
  -  *@upyo/mailgun*: Mailgun transport implementation
  -  *@upyo/sendgrid*: SendGrid transport implementation
  -  *@upyo/ses*: Amazon SES transport implementation
+ -  *@upyo/retry*: Retry and backoff decorator transport
  -  *@upyo/mock*: Mock transport for testing
  -  *@upyo/opentelemetry*: OpenTelemetry observability transport
  -  *docs*: VitePress documentation site
@@ -275,6 +276,8 @@ the application.
 
 #### Utility transports
 
+ -  *@upyo/retry*: Decorator transport that retries transient failures with
+    configurable backoff, jitter, and `sendMany()` throttling
  -  *@upyo/mock*: Testing transport that captures sent messages for inspection
     without external dependencies
  -  *@upyo/opentelemetry*: Decorator transport that adds OpenTelemetry

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,6 +139,18 @@ To be released.
     receipts with the `"pool"` provider id, while child errors keep the
     underlying transport ids as a type-safe union.  [[#25], [#27]]
 
+### @upyo/retry
+
+ -  Added retry transport.  `RetryTransport` wraps any existing transport and
+    retries transient failed receipts or thrown transient errors using
+    configurable exponential backoff, jitter, `Retry-After` metadata, and
+    `sendMany()` launch throttling.  Use it when one provider should absorb
+    temporary rate limits, server errors, and network failures before handing
+    a failure back to application code.  [[#26], [#28]]
+
+[#26]: https://github.com/dahlia/upyo/issues/26
+[#28]: https://github.com/dahlia/upyo/pull/28
+
 ### @upyo/opentelemetry
 
  -  Changed the built-in error category labels from underscore spelling to

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ sending messages.  The following is a list of the available packages:
 | [@upyo/resend](/packages/resend/)               | [JSR][jsr:@upyo/resend]        | [npm][npm:@upyo/resend]        | [Resend] transport                                 |
 | [@upyo/sendgrid](/packages/sendgrid/)           | [JSR][jsr:@upyo/sendgrid]      | [npm][npm:@upyo/sendgrid]      | [SendGrid] transport                               |
 | [@upyo/ses](/packages/ses/)                     | [JSR][jsr:@upyo/ses]           | [npm][npm:@upyo/ses]           | [Amazon SES] transport                             |
+| [@upyo/retry](/packages/retry/)                 | [JSR][jsr:@upyo/retry]         | [npm][npm:@upyo/retry]         | Retry and backoff decorator for transports         |
 | [@upyo/opentelemetry](/packages/opentelemetry/) | [JSR][jsr:@upyo/opentelemetry] | [npm][npm:@upyo/opentelemetry] | [OpenTelemetry] observability  for Upyo transports |
 | [@upyo/mock](/packages/mock/)                   | [JSR][jsr:@upyo/mock]          | [npm][npm:@upyo/mock]          | Mock transport for testing                         |
 
@@ -103,6 +104,8 @@ sending messages.  The following is a list of the available packages:
 [jsr:@upyo/ses]: https://jsr.io/@upyo/ses
 [npm:@upyo/ses]: https://www.npmjs.com/package/@upyo/ses
 [Amazon SES]: https://aws.amazon.com/ses/
+[jsr:@upyo/retry]: https://jsr.io/@upyo/retry
+[npm:@upyo/retry]: https://www.npmjs.com/package/@upyo/retry
 [jsr:@upyo/opentelemetry]: https://jsr.io/@upyo/opentelemetry
 [npm:@upyo/opentelemetry]: https://www.npmjs.com/package/@upyo/opentelemetry
 [OpenTelemetry]: https://opentelemetry.io/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,6 +19,7 @@ const packages: readonly string[] = [
   "resend",
   "smtp",
   "pool",
+  "retry",
   "mock",
 ];
 const jsrRefPlugins: any[] = [];
@@ -80,8 +81,9 @@ const NAV = [
       { text: "Resend", link: "/transports/resend" },
       { text: "SendGrid", link: "/transports/sendgrid" },
       { text: "Amazon SES", link: "/transports/ses" },
-      { text: "OpenTelemetry", link: "/transports/opentelemetry" },
       { text: "Pool transport", link: "/transports/pool" },
+      { text: "Retry transport", link: "/transports/retry" },
+      { text: "OpenTelemetry", link: "/transports/opentelemetry" },
       { text: "Mock transport", link: "/transports/mock" },
       { text: "Custom transport", link: "/transports/custom" },
     ],
@@ -98,6 +100,7 @@ const NAV = [
       { text: "@upyo/resend", link: "https://jsr.io/@upyo/resend/doc" },
       { text: "@upyo/sendgrid", link: "https://jsr.io/@upyo/sendgrid/doc" },
       { text: "@upyo/ses", link: "https://jsr.io/@upyo/ses/doc" },
+      { text: "@upyo/retry", link: "https://jsr.io/@upyo/retry/doc" },
       {
         text: "@upyo/opentelemetry",
         link: "https://jsr.io/@upyo/opentelemetry/doc",

--- a/docs/.vitepress/theme/components/landing/SectionTransports.vue
+++ b/docs/.vitepress/theme/components/landing/SectionTransports.vue
@@ -29,6 +29,7 @@ const providers = [
 
 const utilities = [
   { name: "Pool", desc: "Load-balance and fail over across transports.", link: "/transports/pool" },
+  { name: "Retry", desc: "Backoff and jitter for transient failures.", link: "/transports/retry" },
   { name: "Mock", desc: "Capture messages in tests, send nothing.", link: "/transports/mock" },
   { name: "OpenTelemetry", desc: "Traces and metrics for any transport.", link: "/transports/opentelemetry" },
   { name: "Custom", desc: "Build your own in a couple of methods.", link: "/transports/custom" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,8 @@ description: >-
   Upyo is a small, cross-runtime email library for JavaScript and TypeScript.
   Write a message once and send it on Node.js, Deno, Bun, and edge functions,
   through SMTP or providers like Mailgun, Resend, SendGrid, and Amazon SES,
-  all with the same type-safe API.
+  with retry, failover, testing, and telemetry transports sharing the same
+  type-safe API.
 ---
 
 <script setup>

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "@upyo/plunk": "workspace:",
     "@upyo/pool": "workspace:",
     "@upyo/resend": "workspace:",
+    "@upyo/retry": "workspace:",
     "@upyo/sendgrid": "workspace:",
     "@upyo/ses": "workspace:",
     "@upyo/smtp": "workspace:",

--- a/docs/transports/retry.md
+++ b/docs/transports/retry.md
@@ -122,7 +122,6 @@ You can override classification with `shouldRetry` when a provider needs
 application-specific logic:
 
 ~~~~ typescript twoslash
-import { type Receipt } from "@upyo/core";
 import { MockTransport } from "@upyo/mock";
 import { RetryTransport } from "@upyo/retry";
 
@@ -130,23 +129,14 @@ const baseTransport = new MockTransport();
 
 const transport = new RetryTransport(baseTransport, {
   shouldRetry(failure) {
-    if (isFailedReceipt(failure)) {
-      return failure.errorMessages.some((message) =>
+    if (failure.kind === "receipt") {
+      return failure.receipt.errorMessages.some((message) =>
         message.includes("temporary")
       );
     }
-    return failure instanceof TypeError;
+    return failure.error instanceof TypeError;
   },
 });
-
-function isFailedReceipt(
-  value: unknown,
-): value is Receipt & { readonly successful: false } {
-  return typeof value === "object" &&
-    value != null &&
-    "successful" in value &&
-    value.successful === false;
-}
 ~~~~
 
 

--- a/docs/transports/retry.md
+++ b/docs/transports/retry.md
@@ -1,0 +1,260 @@
+---
+description: >-
+  Retry transport for wrapping Upyo transports with backoff, jitter,
+  Retry-After handling, and sendMany throttling.
+---
+
+Retry transport
+===============
+
+*This transport is introduced in Upyo 0.5.0.*
+
+The retry transport is a decorator that wraps another Upyo transport and
+retries transient delivery failures before returning a final receipt.  It is
+useful when a single provider occasionally returns rate limits, temporary
+server errors, or network failures that should be retried with backoff.
+
+Retrying depends on structured failure metadata from *@upyo/core*.  Transports
+that return failed receipts with `retryable` or structured `errors` fields can
+be retried without custom logic.  Cancellation via `AbortSignal` is never
+retried and still rejects the send operation.
+
+> [!NOTE]
+> Retry transport is not a cross-provider failover system.  To fail over across
+> several providers, use [pool transport](./pool.md), and place retry transport
+> inside or outside the pool depending on whether you want per-provider retries
+> or retries of the whole pooled operation.
+
+
+Installation
+------------
+
+To use retry transport, install the *@upyo/retry* package:
+
+::: code-group
+
+~~~~ sh [npm]
+npm add @upyo/retry
+~~~~
+
+~~~~ sh [pnpm]
+pnpm add @upyo/retry
+~~~~
+
+~~~~ sh [Yarn]
+yarn add @upyo/retry
+~~~~
+
+~~~~ sh [Deno]
+deno add jsr:@upyo/retry
+~~~~
+
+~~~~ sh [Bun]
+bun add @upyo/retry
+~~~~
+
+:::
+
+
+Basic usage
+-----------
+
+Create your regular transport first, then wrap it with `RetryTransport`.
+The wrapper implements the same `Transport` interface and keeps the wrapped
+transport provider id in receipts:
+
+~~~~ typescript twoslash
+import { createFailedReceipt, createMessage } from "@upyo/core";
+import { MockTransport } from "@upyo/mock";
+import { RetryTransport } from "@upyo/retry";
+
+const baseTransport = new MockTransport({
+  defaultResponse: createFailedReceipt("Temporarily unavailable.", {
+    provider: "mock",
+    statusCode: 503,
+  }),
+});
+
+const transport = new RetryTransport(baseTransport, {
+  maxAttempts: 3,
+  backoff: {
+    baseDelayMilliseconds: 1000,
+    maxDelayMilliseconds: 30000,
+    factor: 2,
+  },
+});
+
+const message = createMessage({
+  from: "sender@example.com",
+  to: "recipient@example.com",
+  subject: "Hello",
+  content: { text: "Hello from Upyo." },
+});
+
+const receipt = await transport.send(message);
+
+if (!receipt.successful) {
+  console.error(receipt.errorMessages.join(", "));
+  console.error("Attempts:", receipt.attempts);
+}
+~~~~
+
+By default, retry transport makes up to three total attempts, waits with
+exponential backoff, caps computed delays at 30 seconds, and applies full
+jitter to computed backoff delays.
+
+
+Retry classification
+--------------------
+
+Retry transport uses the final failed receipt from each attempt to decide
+whether another attempt should be made.  It retries when the receipt or one of
+its structured errors is marked retryable.  This includes common transient
+HTTP statuses such as `429`, `408`, and `5xx` when transports expose them as
+structured receipt errors.
+
+If a wrapped transport throws a transient error instead of returning a failed
+receipt, retry transport retries it using the same classifier used by
+*@upyo/core*.  After all attempts are exhausted, thrown delivery failures are
+converted into a failed receipt.  Caller cancellation errors are rethrown.
+
+You can override classification with `shouldRetry` when a provider needs
+application-specific logic:
+
+~~~~ typescript twoslash
+import { type Receipt } from "@upyo/core";
+import { MockTransport } from "@upyo/mock";
+import { RetryTransport } from "@upyo/retry";
+
+const baseTransport = new MockTransport();
+
+const transport = new RetryTransport(baseTransport, {
+  shouldRetry(failure) {
+    if (isFailedReceipt(failure)) {
+      return failure.errorMessages.some((message) =>
+        message.includes("temporary")
+      );
+    }
+    return failure instanceof TypeError;
+  },
+});
+
+function isFailedReceipt(
+  value: unknown,
+): value is Receipt & { readonly successful: false } {
+  return typeof value === "object" &&
+    value != null &&
+    "successful" in value &&
+    value.successful === false;
+}
+~~~~
+
+
+Backoff and `Retry-After`
+-------------------------
+
+Computed retry delays use exponential backoff:
+
+`baseDelayMilliseconds * factor ^ (attempt - 1)`
+:   The delay before the next attempt, capped by `maxDelayMilliseconds`.
+
+`jitter`
+:   `"full"` by default.  Set it to `false` or `"none"` for deterministic
+    computed delays.
+
+`Retry-After`
+:   When a structured receipt error includes `retryAfterMilliseconds`, retry
+    transport uses that provider-supplied delay before computed backoff.  The
+    delay is still capped by `maxDelayMilliseconds`.
+
+Tests or host environments can replace waiting by passing a custom `wait`
+function:
+
+~~~~ typescript twoslash
+import { MockTransport } from "@upyo/mock";
+import { RetryTransport } from "@upyo/retry";
+
+const delays: number[] = [];
+const baseTransport = new MockTransport();
+
+const transport = new RetryTransport(baseTransport, {
+  jitter: false,
+  wait(context, signal) {
+    signal?.throwIfAborted();
+    delays.push(context.delayMilliseconds);
+    return Promise.resolve();
+  },
+});
+~~~~
+
+
+`sendMany()` throttling
+-----------------------
+
+`sendMany()` retries each message independently by calling the wrapped
+transport's `send()` method for each input message.  This means provider-native
+batch APIs are not used through retry transport.  Use the provider transport
+directly when its batch API semantics matter more than per-message retry.
+
+For bulk sends, configure `maxConcurrent` and `intervalMilliseconds` to limit
+how aggressively messages are launched:
+
+~~~~ typescript twoslash
+import { createMessage } from "@upyo/core";
+import { MockTransport } from "@upyo/mock";
+import { RetryTransport } from "@upyo/retry";
+
+const baseTransport = new MockTransport();
+const transport = new RetryTransport(baseTransport, {
+  maxAttempts: 3,
+  sendMany: {
+    maxConcurrent: 4,
+    intervalMilliseconds: 250,
+  },
+});
+
+const messages = [
+  createMessage({
+    from: "sender@example.com",
+    to: "one@example.com",
+    subject: "One",
+    content: { text: "First message." },
+  }),
+  createMessage({
+    from: "sender@example.com",
+    to: "two@example.com",
+    subject: "Two",
+    content: { text: "Second message." },
+  }),
+];
+
+for await (const receipt of transport.sendMany(messages)) {
+  console.log(receipt.successful);
+}
+~~~~
+
+Receipts are yielded in the same order as input messages, even when later
+messages finish first.
+
+
+Composition
+-----------
+
+Retry transport composes with other decorators because it preserves the
+standard Upyo transport interface.  Put it closest to the provider when you
+want provider-level retries before another decorator observes or aggregates
+the result:
+
+~~~~ typescript twoslash
+import { MockTransport } from "@upyo/mock";
+import { createRetryTransport } from "@upyo/retry";
+
+const providerTransport = new MockTransport();
+const transport = createRetryTransport(providerTransport, {
+  maxAttempts: 4,
+});
+~~~~
+
+When wrapping disposable transports, `RetryTransport` forwards async disposal
+to the wrapped transport.  If the wrapped transport only supports synchronous
+disposal, that is used as a fallback.

--- a/packages/plunk/src/plunk-transport.e2e.test.ts
+++ b/packages/plunk/src/plunk-transport.e2e.test.ts
@@ -1,4 +1,4 @@
-import type { Receipt } from "@upyo/core";
+import { createFailedReceipt, type Receipt } from "@upyo/core";
 import { PlunkTransport } from "@upyo/plunk";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
@@ -28,10 +28,9 @@ describeE2E("PlunkTransport E2E", () => {
 
     const receipt = await transport.send(message);
 
-    assert.equal(receipt.successful, true, "Send should be successful");
-    if (receipt.successful) {
-      assert.ok(receipt.messageId, "Should have a message ID");
-    }
+    if (acceptQuotaLimit(receipt, "Simple text email")) return;
+
+    assertSuccessful(receipt);
 
     if (receipt.successful) {
       console.log(`Sent email with ID: ${receipt.messageId}`);
@@ -50,10 +49,9 @@ describeE2E("PlunkTransport E2E", () => {
 
     const receipt = await transport.send(message);
 
-    assert.equal(receipt.successful, true, "Send should be successful");
-    if (receipt.successful) {
-      assert.ok(receipt.messageId, "Should have a message ID");
-    }
+    if (acceptQuotaLimit(receipt, "HTML email")) return;
+
+    assertSuccessful(receipt);
 
     if (receipt.successful) {
       console.log(`Sent HTML email with ID: ${receipt.messageId}`);
@@ -106,10 +104,9 @@ describeE2E("PlunkTransport E2E", () => {
 
     const receipt = await transport.send(message);
 
-    assert.equal(receipt.successful, true, "Send should be successful");
-    if (receipt.successful) {
-      assert.ok(receipt.messageId, "Should have a message ID");
-    }
+    if (acceptQuotaLimit(receipt, "Custom headers email")) return;
+
+    assertSuccessful(receipt);
 
     if (receipt.successful) {
       console.log(`Sent email with custom headers, ID: ${receipt.messageId}`);
@@ -131,10 +128,9 @@ describeE2E("PlunkTransport E2E", () => {
 
     const receipt = await transport.send(message);
 
-    assert.equal(receipt.successful, true, "Send should be successful");
-    if (receipt.successful) {
-      assert.ok(receipt.messageId, "Should have a message ID");
-    }
+    if (acceptQuotaLimit(receipt, "Reply-to email")) return;
+
+    assertSuccessful(receipt);
 
     if (receipt.successful) {
       console.log(`Sent email with reply-to, ID: ${receipt.messageId}`);
@@ -165,6 +161,10 @@ describeE2E("PlunkTransport E2E", () => {
     }
 
     assert.equal(receipts.length, 3, "Should send all three emails");
+    if (isQuotaLimitedBatch(receipts)) {
+      console.log("Batch email test skipped due to Plunk transactional limit.");
+      return;
+    }
     assert.ok(
       receipts.every((r) => r.successful),
       "All sends should be successful",
@@ -220,3 +220,50 @@ describeE2E("PlunkTransport E2E", () => {
     console.log(`Timeout test failed as expected: ${receipt.errorMessages[0]}`);
   });
 });
+
+describe("PlunkTransport E2E quota helpers", () => {
+  it("only skips batches when all failures are quota limits", () => {
+    const success: Receipt = { successful: true, messageId: "sent" };
+    const quotaLimit = createFailedReceipt("Plunk transactional limit.", {
+      provider: "plunk",
+      statusCode: 402,
+    });
+    const authFailure = createFailedReceipt("Unauthorized.", {
+      provider: "plunk",
+      statusCode: 401,
+    });
+
+    assert.equal(isQuotaLimitedBatch([success]), false);
+    assert.equal(isQuotaLimitedBatch([success, quotaLimit]), true);
+    assert.equal(
+      isQuotaLimitedBatch([success, quotaLimit, authFailure]),
+      false,
+    );
+  });
+});
+
+function assertSuccessful(receipt: Receipt): asserts receipt is Receipt & {
+  readonly successful: true;
+} {
+  assert.equal(receipt.successful, true, "Send should be successful");
+  assert.ok(receipt.messageId, "Should have a message ID");
+}
+
+function acceptQuotaLimit(receipt: Receipt, label: string): boolean {
+  if (!isQuotaLimitReceipt(receipt)) return false;
+  console.log(`${label} test skipped due to Plunk transactional limit.`);
+  return true;
+}
+
+function isQuotaLimitedBatch(receipts: readonly Receipt[]): boolean {
+  const failures = receipts.filter((receipt) => !receipt.successful);
+  return failures.length > 0 && failures.every(isQuotaLimitReceipt);
+}
+
+function isQuotaLimitReceipt(receipt: Receipt): boolean {
+  return !receipt.successful &&
+    receipt.errors?.some((error) => error.statusCode === 402) === true &&
+    receipt.errorMessages.some((message) =>
+      message.includes("transactional limit")
+    );
+}

--- a/packages/plunk/src/plunk-transport.e2e.test.ts
+++ b/packages/plunk/src/plunk-transport.e2e.test.ts
@@ -233,11 +233,10 @@ describe("PlunkTransport E2E quota helpers", () => {
       statusCode: 401,
     });
 
-    assert.equal(isQuotaLimitedBatch([success]), false);
-    assert.equal(isQuotaLimitedBatch([success, quotaLimit]), true);
-    assert.equal(
-      isQuotaLimitedBatch([success, quotaLimit, authFailure]),
-      false,
+    assert.ok(!isQuotaLimitedBatch([success]));
+    assert.ok(isQuotaLimitedBatch([success, quotaLimit]));
+    assert.ok(
+      !isQuotaLimitedBatch([success, quotaLimit, authFailure]),
     );
   });
 });
@@ -245,7 +244,7 @@ describe("PlunkTransport E2E quota helpers", () => {
 function assertSuccessful(receipt: Receipt): asserts receipt is Receipt & {
   readonly successful: true;
 } {
-  assert.equal(receipt.successful, true, "Send should be successful");
+  assert.ok(receipt.successful, "Send should be successful");
   assert.ok(receipt.messageId, "Should have a message ID");
 }
 

--- a/packages/retry/README.md
+++ b/packages/retry/README.md
@@ -1,0 +1,46 @@
+<!-- deno-fmt-ignore-file -->
+
+@upyo/retry
+===========
+
+*@upyo/retry* provides a retry and backoff decorator for Upyo transports.
+It wraps any `Transport` implementation without changing the transport
+interface, so it can be composed with SMTP, HTTP API transports, pool
+transports, and OpenTelemetry instrumentation.
+
+
+Installation
+------------
+
+~~~~ bash
+deno add jsr:@upyo/retry
+pnpm add @upyo/retry
+~~~~
+
+
+Usage
+-----
+
+~~~~ typescript
+import { RetryTransport } from "@upyo/retry";
+import { MailgunTransport } from "@upyo/mailgun";
+
+const baseTransport = new MailgunTransport({
+  apiKey: "your-mailgun-api-key",
+  domain: "mg.example.com",
+});
+
+const transport = new RetryTransport(baseTransport, {
+  maxAttempts: 3,
+  backoff: {
+    baseDelayMilliseconds: 1000,
+    maxDelayMilliseconds: 30000,
+    factor: 2,
+  },
+});
+~~~~
+
+The retry transport uses structured Upyo failure receipts to distinguish
+transient failures, such as rate limits and temporary server errors, from
+permanent failures, such as validation or authentication errors.  It also
+honors provider-supplied `Retry-After` metadata when available.

--- a/packages/retry/deno.json
+++ b/packages/retry/deno.json
@@ -1,0 +1,9 @@
+{
+  "name": "@upyo/retry",
+  "version": "0.5.0",
+  "license": "MIT",
+  "exports": "./src/index.ts",
+  "exclude": [
+    "dist/"
+  ]
+}

--- a/packages/retry/mise.toml
+++ b/packages/retry/mise.toml
@@ -2,13 +2,13 @@
 _.file = { path = ".env", redact = true }
 
 [tasks.build]
-description = "Build @upyo/lettermint"
+description = "Build @upyo/retry"
 run = "pnpm exec tsdown"
 sources = ["deno.json", "package.json", "tsdown.config.ts", "src/**/*.ts", "../../pnpm-lock.yaml", "../../pnpm-workspace.yaml"]
 outputs = ["dist/**/*"]
 
 [tasks."test:deno"]
-description = "Run @upyo/lettermint tests with Deno"
+description = "Run @upyo/retry tests with Deno"
 usage = '''
 flag "--coverage" help="Collect coverage data"
 flag "--junit-path <path>" help="Write JUnit XML test output"
@@ -31,15 +31,15 @@ deno ...$args
 '''
 
 [tasks."test:node"]
-description = "Run @upyo/lettermint tests with Node.js"
+description = "Run @upyo/retry tests with Node.js"
 depends = ["build"]
 run = "node --experimental-transform-types --test"
 
 [tasks."test:bun"]
-description = "Run @upyo/lettermint tests with Bun"
+description = "Run @upyo/retry tests with Bun"
 depends = ["build"]
-run = "bun test --timeout=90000"
+run = "bun test --timeout=30000"
 
 [tasks.test]
-description = "Run @upyo/lettermint tests across all runtimes"
+description = "Run @upyo/retry tests across all runtimes"
 depends = ["test:deno", "test:node", "test:bun"]

--- a/packages/retry/package.json
+++ b/packages/retry/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@upyo/retry",
+  "version": "0.5.0",
+  "description": "Retry and backoff decorator transport for Upyo email library",
+  "keywords": [
+    "email",
+    "mail",
+    "retry",
+    "backoff",
+    "rate-limit"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Hong Minhee",
+    "email": "hong@minhee.org",
+    "url": "https://hongminhee.org/"
+  },
+  "homepage": "https://upyo.org/transports/retry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dahlia/upyo.git",
+    "directory": "packages/retry/"
+  },
+  "bugs": {
+    "url": "https://github.com/dahlia/upyo/issues"
+  },
+  "funding": [
+    "https://github.com/sponsors/dahlia"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "bun": ">=1.2.0",
+    "deno": ">=2.3.0"
+  },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "peerDependencies": {
+    "@upyo/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "prepack": "mise run --no-deps :build",
+    "prepublish": "mise run --no-deps :build"
+  }
+}

--- a/packages/retry/src/config.ts
+++ b/packages/retry/src/config.ts
@@ -1,0 +1,302 @@
+import type { Receipt } from "@upyo/core";
+
+/**
+ * Jitter mode for computed retry delays.
+ *
+ * @since 0.5.0
+ */
+export type JitterConfig = false | "none" | "full";
+
+/**
+ * Exponential backoff settings for retry delays.
+ *
+ * @since 0.5.0
+ */
+export interface BackoffConfig {
+  /**
+   * Delay before the first retry, in milliseconds.
+   *
+   * @default 1000
+   */
+  readonly baseDelayMilliseconds?: number;
+
+  /**
+   * Maximum computed delay, in milliseconds.
+   *
+   * @default 30000
+   */
+  readonly maxDelayMilliseconds?: number;
+
+  /**
+   * Multiplier applied after each failed attempt.
+   *
+   * @default 2
+   */
+  readonly factor?: number;
+}
+
+/**
+ * Context passed to custom retry wait functions.
+ *
+ * @since 0.5.0
+ */
+export interface DelayContext<TProviderId extends string = string> {
+  /**
+   * Attempt that just failed.
+   */
+  readonly attempt: number;
+
+  /**
+   * Attempt that will run after this delay.
+   */
+  readonly nextAttempt: number;
+
+  /**
+   * Maximum configured attempts.
+   */
+  readonly maxAttempts: number;
+
+  /**
+   * Delay to wait before retrying, in milliseconds.
+   */
+  readonly delayMilliseconds: number;
+
+  /**
+   * Failed receipt that caused the retry, when the transport returned one.
+   */
+  readonly receipt?: Receipt<TProviderId> & { readonly successful: false };
+
+  /**
+   * Thrown error that caused the retry, when the transport rejected.
+   */
+  readonly error?: unknown;
+
+  /**
+   * Why the delay is being applied.
+   */
+  readonly reason: "retry" | "sendMany-throttle";
+}
+
+/**
+ * Function used to wait between attempts or throttled sends.
+ *
+ * @param context Information about the delay being applied.
+ * @param signal Abort signal that should cancel the wait.
+ * @returns A promise that resolves when the delay is complete.
+ * @throws {DOMException} If the wait is aborted.
+ * @since 0.5.0
+ */
+export type WaitFunction<TProviderId extends string = string> = (
+  context: DelayContext<TProviderId>,
+  signal?: AbortSignal,
+) => Promise<void>;
+
+/**
+ * Function that decides whether a failure should be retried.
+ *
+ * @param failure Failed receipt or thrown error.
+ * @returns Whether another attempt should be made.
+ * @since 0.5.0
+ */
+export type RetryClassifier<TProviderId extends string = string> = (
+  failure:
+    | (Receipt<TProviderId> & { readonly successful: false })
+    | unknown,
+) => boolean;
+
+/**
+ * Retry behavior for `sendMany()`.
+ *
+ * @since 0.5.0
+ */
+export interface SendManyRetryConfig {
+  /**
+   * Maximum number of messages to send at the same time.
+   *
+   * @default 1
+   */
+  readonly maxConcurrent?: number;
+
+  /**
+   * Minimum delay between launching message sends, in milliseconds.
+   *
+   * @default 0
+   */
+  readonly intervalMilliseconds?: number;
+}
+
+/**
+ * Configuration for the retry transport decorator.
+ *
+ * @since 0.5.0
+ */
+export interface RetryConfig<TProviderId extends string = string> {
+  /**
+   * Total number of send attempts, including the first one.
+   *
+   * @default 3
+   */
+  readonly maxAttempts?: number;
+
+  /**
+   * Exponential backoff settings.
+   */
+  readonly backoff?: BackoffConfig;
+
+  /**
+   * Jitter mode applied to computed backoff delays.
+   *
+   * `Retry-After` delays are not jittered.
+   *
+   * @default "full"
+   */
+  readonly jitter?: JitterConfig;
+
+  /**
+   * Random number source for jitter.
+   *
+   * @default Math.random
+   */
+  readonly random?: () => number;
+
+  /**
+   * Custom retry classifier.
+   */
+  readonly shouldRetry?: RetryClassifier<TProviderId>;
+
+  /**
+   * Custom wait function for tests or host-controlled scheduling.
+   */
+  readonly wait?: WaitFunction<TProviderId>;
+
+  /**
+   * Retry and throttling behavior for `sendMany()`.
+   */
+  readonly sendMany?: SendManyRetryConfig;
+}
+
+/**
+ * Resolved retry configuration with defaults applied.
+ *
+ * @since 0.5.0
+ */
+export interface ResolvedRetryConfig<TProviderId extends string = string> {
+  readonly maxAttempts: number;
+  readonly backoff: Required<BackoffConfig>;
+  readonly jitter: JitterConfig;
+  readonly random: () => number;
+  readonly shouldRetry?: RetryClassifier<TProviderId>;
+  readonly wait: WaitFunction<TProviderId>;
+  readonly sendMany: Required<SendManyRetryConfig>;
+}
+
+/**
+ * Creates a resolved retry configuration.
+ *
+ * @param config Retry configuration.
+ * @returns The resolved configuration.
+ * @throws {RangeError} If a numeric option is out of range.
+ * @since 0.5.0
+ */
+export function createRetryConfig<TProviderId extends string = string>(
+  config: RetryConfig<TProviderId> = {},
+): ResolvedRetryConfig<TProviderId> {
+  const maxAttempts = config.maxAttempts ?? 3;
+  const baseDelayMilliseconds = config.backoff?.baseDelayMilliseconds ?? 1000;
+  const maxDelayMilliseconds = config.backoff?.maxDelayMilliseconds ?? 30000;
+  const factor = config.backoff?.factor ?? 2;
+  const maxConcurrent = config.sendMany?.maxConcurrent ?? 1;
+  const intervalMilliseconds = config.sendMany?.intervalMilliseconds ?? 0;
+
+  assertIntegerAtLeast(maxAttempts, 1, "maxAttempts");
+  assertFiniteAtLeast(
+    baseDelayMilliseconds,
+    0,
+    "backoff.baseDelayMilliseconds",
+  );
+  assertFiniteAtLeast(
+    maxDelayMilliseconds,
+    0,
+    "backoff.maxDelayMilliseconds",
+  );
+  assertFiniteAtLeast(factor, 1, "backoff.factor");
+  assertIntegerAtLeast(maxConcurrent, 1, "sendMany.maxConcurrent");
+  assertFiniteAtLeast(
+    intervalMilliseconds,
+    0,
+    "sendMany.intervalMilliseconds",
+  );
+
+  return {
+    maxAttempts,
+    backoff: {
+      baseDelayMilliseconds,
+      maxDelayMilliseconds,
+      factor,
+    },
+    jitter: config.jitter ?? "full",
+    random: config.random ?? Math.random,
+    shouldRetry: config.shouldRetry,
+    wait: config.wait ?? defaultWait,
+    sendMany: {
+      maxConcurrent,
+      intervalMilliseconds,
+    },
+  };
+}
+
+async function defaultWait(
+  context: DelayContext,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  if (context.delayMilliseconds <= 0) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => signal?.removeEventListener("abort", abort);
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, context.delayMilliseconds);
+    const abort = () => {
+      clearTimeout(timeout);
+      cleanup();
+      reject(createAbortError());
+    };
+
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function assertIntegerAtLeast(
+  value: number,
+  minimum: number,
+  name: string,
+): void {
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new RangeError(
+      `${name} must be an integer greater than or equal to ${minimum}.`,
+    );
+  }
+}
+
+function assertFiniteAtLeast(
+  value: number,
+  minimum: number,
+  name: string,
+): void {
+  if (!Number.isFinite(value) || value < minimum) {
+    throw new RangeError(
+      `${name} must be greater than or equal to ${minimum}.`,
+    );
+  }
+}
+
+function createAbortError(): DOMException {
+  return new DOMException("The operation was aborted.", "AbortError");
+}

--- a/packages/retry/src/config.ts
+++ b/packages/retry/src/config.ts
@@ -1,4 +1,4 @@
-import type { Receipt } from "@upyo/core";
+import type { Receipt, ReceiptError } from "@upyo/core";
 
 /**
  * Jitter mode for computed retry delays.
@@ -92,16 +92,30 @@ export type WaitFunction<TProviderId extends string = string> = (
 ) => Promise<void>;
 
 /**
+ * Failure passed to a custom retry classifier.
+ *
+ * @since 0.5.0
+ */
+export type RetryFailure<TProviderId extends string = string> =
+  | {
+    readonly kind: "receipt";
+    readonly receipt: Receipt<TProviderId> & { readonly successful: false };
+  }
+  | {
+    readonly kind: "error";
+    readonly error: unknown;
+    readonly receiptError?: ReceiptError<TProviderId>;
+  };
+
+/**
  * Function that decides whether a failure should be retried.
  *
- * @param failure Failed receipt or thrown error.
+ * @param failure Failed receipt or thrown error metadata.
  * @returns Whether another attempt should be made.
  * @since 0.5.0
  */
 export type RetryClassifier<TProviderId extends string = string> = (
-  failure:
-    | (Receipt<TProviderId> & { readonly successful: false })
-    | unknown,
+  failure: RetryFailure<TProviderId>,
 ) => boolean;
 
 /**
@@ -261,7 +275,7 @@ async function defaultWait(
     const abort = () => {
       clearTimeout(timeout);
       cleanup();
-      reject(createAbortError());
+      reject(signal?.reason ?? createAbortError());
     };
 
     if (signal?.aborted) {

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -5,6 +5,7 @@ export type {
   JitterConfig,
   RetryClassifier,
   RetryConfig,
+  RetryFailure,
   SendManyRetryConfig,
   WaitFunction,
 } from "./config.ts";

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -1,0 +1,10 @@
+export { createRetryTransport, RetryTransport } from "./retry-transport.ts";
+export type {
+  BackoffConfig,
+  DelayContext,
+  JitterConfig,
+  RetryClassifier,
+  RetryConfig,
+  SendManyRetryConfig,
+  WaitFunction,
+} from "./config.ts";

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -102,6 +102,31 @@ describe("RetryTransport", () => {
     assert.deepEqual(delays, [2_000]);
   });
 
+  it("preserves zero Retry-After metadata", async () => {
+    const delays: number[] = [];
+    const base = new SequenceTransport([
+      createFailedReceipt(createReceiptError("Rate limited", {
+        provider: "base",
+        statusCode: 429,
+        retryAfterMilliseconds: 0,
+      })),
+      { successful: true, messageId: "delivered" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      backoff: { baseDelayMilliseconds: 100 },
+      jitter: false,
+      wait: (context) => {
+        delays.push(context.delayMilliseconds);
+        return Promise.resolve();
+      },
+    });
+
+    await transport.send(message());
+
+    assert.deepEqual(delays, [0]);
+  });
+
   it("ignores invalid Retry-After metadata", async () => {
     const invalidRetryAfterValues = [NaN, -1, Infinity];
 
@@ -561,6 +586,40 @@ describe("RetryTransport", () => {
       () => Promise.race([next, rejectAfter(50)]),
       (error) => error === reason,
     );
+  });
+
+  it("rejects pending sendMany sends when aborted", async () => {
+    const controller = new AbortController();
+    const reason = new TypeError("Stop pending sends.");
+    const releaseSend = createDeferred<void>();
+    const events: string[] = [];
+    const base = new TrackingTransport(async (_message, index) => {
+      events.push(`start:${index}`);
+      await releaseSend.promise;
+      return { successful: true, messageId: `message-${index}` };
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 1 },
+    });
+
+    const iterator = transport.sendMany([message("First")], {
+      signal: controller.signal,
+    })[Symbol.asyncIterator]();
+    const next = iterator.next();
+
+    await waitFor(() => events.includes("start:0"));
+    controller.abort(reason);
+
+    try {
+      await assert.rejects(
+        () => Promise.race([next, rejectAfter(50)]),
+        (error) => error === reason,
+      );
+    } finally {
+      releaseSend.resolve();
+      await next.catch(() => undefined);
+    }
   });
 
   it("yields queued sendMany receipts before launch errors", async () => {

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -259,7 +259,7 @@ describe("RetryTransport", () => {
   it("rejects caller aborts after wrapped sends", async () => {
     const controller = new AbortController();
     const reason = new TypeError("Stop after send.");
-    const releaseSend = Promise.withResolvers<void>();
+    const releaseSend = createDeferred<void>();
     const base = new TrackingTransport(async () => {
       await releaseSend.promise;
       return { successful: true, messageId: "should-not-deliver" };
@@ -403,8 +403,8 @@ describe("RetryTransport", () => {
     const events: string[] = [];
     let active = 0;
     let maxActive = 0;
-    const releaseFirst = Promise.withResolvers<void>();
-    const releaseSecond = Promise.withResolvers<void>();
+    const releaseFirst = createDeferred<void>();
+    const releaseSecond = createDeferred<void>();
     const releases = [releaseFirst.promise, releaseSecond.promise];
     const base = new TrackingTransport(async (_message, index) => {
       active++;
@@ -455,7 +455,7 @@ describe("RetryTransport", () => {
   });
 
   it("yields completed sendMany receipts before slow async input", async () => {
-    const releaseSecond = Promise.withResolvers<void>();
+    const releaseSecond = createDeferred<void>();
     async function* messages(): AsyncIterable<Message> {
       yield message("First");
       await releaseSecond.promise;
@@ -497,7 +497,7 @@ describe("RetryTransport", () => {
 
   it("surfaces sendMany input errors after yielding ready receipts", async () => {
     const inputError = new TypeError("Input failed.");
-    const releaseFailure = Promise.withResolvers<void>();
+    const releaseFailure = createDeferred<void>();
     async function* messages(): AsyncIterable<Message> {
       yield message("First");
       await releaseFailure.promise;
@@ -530,7 +530,7 @@ describe("RetryTransport", () => {
   it("rejects pending sendMany input pulls when aborted", async () => {
     const controller = new AbortController();
     const reason = new TypeError("Stop reading input.");
-    const releaseSecond = Promise.withResolvers<void>();
+    const releaseSecond = createDeferred<void>();
     async function* messages(): AsyncIterable<Message> {
       yield message("First");
       await releaseSecond.promise;
@@ -628,7 +628,7 @@ describe("RetryTransport", () => {
   it("drains already-launched sendMany receipts before launch errors", async () => {
     const inputError = new TypeError("Input failed.");
     const events: string[] = [];
-    const releaseFirst = Promise.withResolvers<void>();
+    const releaseFirst = createDeferred<void>();
     const messages: Iterable<Message> = {
       [Symbol.iterator]() {
         let index = 0;
@@ -683,7 +683,7 @@ describe("RetryTransport", () => {
   });
 
   it("does not hang when closed with a pending sendMany input pull", async () => {
-    const never = Promise.withResolvers<void>();
+    const never = createDeferred<void>();
     async function* messages(): AsyncIterable<Message> {
       yield message("First");
       await never.promise;
@@ -711,7 +711,7 @@ describe("RetryTransport", () => {
   });
 
   it("closes pending sendMany input pulls when consumers stop early", async () => {
-    const pendingPullStarted = Promise.withResolvers<void>();
+    const pendingPullStarted = createDeferred<void>();
     let closed = false;
     const messages: AsyncIterable<Message> = {
       [Symbol.asyncIterator]() {
@@ -761,7 +761,7 @@ describe("RetryTransport", () => {
   });
 
   it("yields completed sendMany receipts while throttling launches", async () => {
-    const releaseThrottle = Promise.withResolvers<void>();
+    const releaseThrottle = createDeferred<void>();
     const base = new TrackingTransport((_message, index) =>
       Promise.resolve({
         successful: true,
@@ -807,7 +807,7 @@ describe("RetryTransport", () => {
 
   it("refills sendMany concurrency when later messages finish first", async () => {
     const events: string[] = [];
-    const releaseFirst = Promise.withResolvers<void>();
+    const releaseFirst = createDeferred<void>();
     const base = new TrackingTransport(async (_message, index) => {
       events.push(`start:${index}`);
       if (index === 0) await releaseFirst.promise;
@@ -847,7 +847,7 @@ describe("RetryTransport", () => {
 
   it("stops launching sendMany messages after queued send failures", async () => {
     const sendError = new TypeError("Retry policy failed.");
-    const releaseFirst = Promise.withResolvers<void>();
+    const releaseFirst = createDeferred<void>();
     const events: string[] = [];
     const base = new TrackingTransport(async (_message, index) => {
       events.push(`start:${index}`);
@@ -889,7 +889,7 @@ describe("RetryTransport", () => {
   });
 
   it("keeps later sendMany thrown failures ordered", async () => {
-    const releaseFirst = Promise.withResolvers<void>();
+    const releaseFirst = createDeferred<void>();
     const base = new TrackingTransport(async (_message, index) => {
       if (index === 1) throw createAbortError();
       await releaseFirst.promise;
@@ -957,7 +957,7 @@ describe("RetryTransport", () => {
 
   it("cancels pending sendMany launch waits when consumers stop early", async () => {
     const events: string[] = [];
-    const releaseFirst = Promise.withResolvers<void>();
+    const releaseFirst = createDeferred<void>();
     let waitStarted = false;
     let waitAborted = false;
     const base = new TrackingTransport(async (_message, index) => {
@@ -1047,6 +1047,24 @@ async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
   const result: T[] = [];
   for await (const value of values) result.push(value);
   return result;
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (reason?: unknown) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve: Deferred<T>["resolve"] | undefined;
+  let reject: Deferred<T>["reject"] | undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  assert.ok(resolve != null);
+  assert.ok(reject != null);
+  return { promise, resolve, reject };
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -578,6 +578,55 @@ describe("RetryTransport", () => {
     assert.ok(await settlesWithin(returned, 50));
   });
 
+  it("closes pending sendMany input pulls when consumers stop early", async () => {
+    const pendingPullStarted = Promise.withResolvers<void>();
+    let closed = false;
+    const messages: AsyncIterable<Message> = {
+      [Symbol.asyncIterator]() {
+        let index = 0;
+        return {
+          next(): Promise<IteratorResult<Message>> {
+            if (index++ === 0) {
+              return Promise.resolve({
+                done: false,
+                value: message("First"),
+              });
+            }
+            pendingPullStarted.resolve();
+            return new Promise<IteratorResult<Message>>(() => {});
+          },
+          return(): Promise<IteratorResult<Message>> {
+            closed = true;
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        };
+      },
+    };
+    const base = new TrackingTransport((_message, index) =>
+      Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      })
+    );
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const iterator = transport.sendMany(messages)[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
+    await pendingPullStarted.promise;
+
+    const returned = iterator.return?.();
+    assert.ok(returned != null);
+    assert.ok(await settlesWithin(returned, 50));
+    await waitFor(() => closed);
+
+    assert.ok(closed);
+  });
+
   it("yields completed sendMany receipts while throttling launches", async () => {
     const releaseThrottle = Promise.withResolvers<void>();
     const base = new TrackingTransport((_message, index) =>

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -496,6 +496,60 @@ describe("RetryTransport", () => {
     await assert.rejects(() => iterator.next(), inputError);
   });
 
+  it("drains already-launched sendMany receipts before launch errors", async () => {
+    const inputError = new TypeError("Input failed.");
+    const events: string[] = [];
+    const releaseFirst = Promise.withResolvers<void>();
+    const messages: Iterable<Message> = {
+      [Symbol.iterator]() {
+        let index = 0;
+        return {
+          next(): IteratorResult<Message> {
+            if (index < 2) {
+              return { done: false, value: message(`Message ${index++}`) };
+            }
+            events.push("input-error");
+            throw inputError;
+          },
+        };
+      },
+    };
+    const base = new TrackingTransport(async (_message, index) => {
+      events.push(`start:${index}`);
+      if (index === 0) await releaseFirst.promise;
+      events.push(`finish:${index}`);
+      return { successful: true, messageId: `message-${index}` };
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const iterator = transport.sendMany(messages)[Symbol.asyncIterator]();
+    const firstResult = iterator.next();
+
+    await waitFor(() => events.includes("input-error"));
+    assert.ok(!await settlesWithin(firstResult));
+
+    releaseFirst.resolve();
+
+    const first = await firstResult;
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
+    if (first.value.successful) {
+      assert.equal(first.value.messageId, "message-0");
+    }
+
+    const second = await iterator.next();
+    assert.ok(!second.done);
+    assert.ok(second.value.successful);
+    if (second.value.successful) {
+      assert.equal(second.value.messageId, "message-1");
+    }
+
+    await assert.rejects(() => iterator.next(), inputError);
+  });
+
   it("does not hang when closed with a pending sendMany input pull", async () => {
     const never = Promise.withResolvers<void>();
     async function* messages(): AsyncIterable<Message> {

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -250,6 +250,25 @@ describe("RetryTransport", () => {
     assert.equal(base.calls, 1);
   });
 
+  it("propagates custom retry wait rejections", async () => {
+    const waitError = new TypeError("Retry scheduler failed.");
+    const base = new SequenceTransport([
+      createFailedReceipt("Service unavailable", {
+        provider: "base",
+        statusCode: 503,
+      }),
+      { successful: true, messageId: "should-not-send" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      jitter: false,
+      wait: () => Promise.reject(waitError),
+    });
+
+    await assert.rejects(() => transport.send(message()), waitError);
+    assert.equal(base.calls, 1);
+  });
+
   it("preserves custom abort reasons during the default retry wait", async () => {
     const controller = new AbortController();
     const reason = new TypeError("Stop retrying.");

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -600,6 +600,31 @@ describe("RetryTransport", () => {
     await assert.rejects(() => iterator.next(), inputError);
   });
 
+  it("accepts primitive sync iterables in sendMany", async () => {
+    let calls = 0;
+    const base = new TrackingTransport((_message, index) => {
+      calls++;
+      return Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      });
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 1 },
+    });
+
+    const receipts = await collect(
+      transport.sendMany("ab" as unknown as Iterable<Message>),
+    );
+
+    assert.equal(calls, 2);
+    assert.deepEqual(
+      receipts.map((receipt) => receipt.successful && receipt.messageId),
+      ["message-0", "message-1"],
+    );
+  });
+
   it("drains already-launched sendMany receipts before launch errors", async () => {
     const inputError = new TypeError("Input failed.");
     const events: string[] = [];
@@ -818,6 +843,49 @@ describe("RetryTransport", () => {
       receipts.map((receipt) => receipt.successful && receipt.messageId),
       ["message-0", "message-1", "message-2"],
     );
+  });
+
+  it("stops launching sendMany messages after queued send failures", async () => {
+    const sendError = new TypeError("Retry policy failed.");
+    const releaseFirst = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const base = new TrackingTransport(async (_message, index) => {
+      events.push(`start:${index}`);
+      if (index === 0) {
+        await releaseFirst.promise;
+        return { successful: true, messageId: "first" };
+      }
+      return createFailedReceipt("Service unavailable.", {
+        provider: "base",
+        retryable: true,
+      });
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      sendMany: { maxConcurrent: 2 },
+      wait: () => Promise.reject(sendError),
+    });
+
+    const iterator = transport.sendMany([
+      message("First"),
+      message("Second"),
+      message("Third"),
+    ])[Symbol.asyncIterator]();
+    const firstResult = iterator.next();
+
+    await waitFor(() => events.includes("start:1"));
+    await Promise.resolve();
+    assert.deepEqual(events, ["start:0", "start:1"]);
+
+    releaseFirst.resolve();
+    const first = await firstResult;
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
+    await assert.rejects(
+      () => iterator.next(),
+      (error) => error === sendError,
+    );
+    assert.deepEqual(events, ["start:0", "start:1"]);
   });
 
   it("keeps later sendMany thrown failures ordered", async () => {

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -438,6 +438,43 @@ describe("RetryTransport", () => {
     await assert.rejects(() => iterator.next(), inputError);
   });
 
+  it("yields queued sendMany receipts before launch errors", async () => {
+    const inputError = new TypeError("Input failed.");
+    const messages: Iterable<Message> = {
+      [Symbol.iterator]() {
+        let index = 0;
+        return {
+          next(): IteratorResult<Message> {
+            if (index++ === 0) {
+              return { done: false, value: message("First") };
+            }
+            throw inputError;
+          },
+        };
+      },
+    };
+    const base = new TrackingTransport((_message, index) =>
+      Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      })
+    );
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const iterator = transport.sendMany(messages)[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
+    if (first.value.successful) {
+      assert.equal(first.value.messageId, "message-0");
+    }
+
+    await assert.rejects(() => iterator.next(), inputError);
+  });
+
   it("does not hang when closed with a pending sendMany input pull", async () => {
     const never = Promise.withResolvers<void>();
     async function* messages(): AsyncIterable<Message> {

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -39,7 +39,7 @@ describe("RetryTransport", () => {
     const receipt = await transport.send(message());
 
     assert.equal(base.calls, 2);
-    assert.equal(receipt.successful, true);
+    assert.ok(receipt.successful);
     assert.equal(receipt.messageId, "delivered");
     assert.equal(receipt.provider, "base");
     assert.equal(receipt.attempts, 2);
@@ -67,7 +67,7 @@ describe("RetryTransport", () => {
     const receipt = await transport.send(message());
 
     assert.equal(base.calls, 1);
-    assert.equal(receipt.successful, false);
+    assert.ok(!receipt.successful);
     assert.deepEqual(receipt.errorMessages, ["Invalid recipient"]);
     assert.equal(receipt.provider, "base");
     assert.equal(receipt.attempts, 1);
@@ -116,9 +116,9 @@ describe("RetryTransport", () => {
     const receipt = await transport.send(message());
 
     assert.equal(base.calls, 2);
-    assert.equal(receipt.successful, false);
+    assert.ok(!receipt.successful);
     assert.deepEqual(receipt.errorMessages, ["Connection reset by peer"]);
-    assert.equal(receipt.retryable, true);
+    assert.ok(receipt.retryable);
     assert.equal(receipt.provider, "base");
     assert.equal(receipt.attempts, 2);
     assert.equal(receipt.errors?.[0]?.category, "network");
@@ -138,7 +138,26 @@ describe("RetryTransport", () => {
     const receipt = await transport.send(message());
 
     assert.equal(base.calls, 2);
-    assert.equal(receipt.successful, true);
+    assert.ok(receipt.successful);
+    assert.equal(receipt.messageId, "delivered");
+    assert.equal(receipt.attempts, 2);
+  });
+
+  it("retries provider AbortErrors without timeout messages", async () => {
+    const base = new SequenceTransport([
+      createAbortError(),
+      { successful: true, messageId: "delivered" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      jitter: false,
+      wait: () => Promise.resolve(),
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 2);
+    assert.ok(receipt.successful);
     assert.equal(receipt.messageId, "delivered");
     assert.equal(receipt.attempts, 2);
   });
@@ -164,7 +183,7 @@ describe("RetryTransport", () => {
     const receipt = await transport.send(message());
 
     assert.equal(base.calls, 2);
-    assert.equal(receipt.successful, true);
+    assert.ok(receipt.successful);
     assert.equal(errors.length, 1);
     assert.equal(errors[0], base.results[0]);
   });
@@ -256,9 +275,9 @@ describe("RetryTransport", () => {
 
     assert.equal(base.calls, 2);
     assert.deepEqual(delays, [5_000]);
-    assert.equal(receipt.successful, false);
+    assert.ok(!receipt.successful);
     assert.deepEqual(receipt.errorMessages, ["Rate limited."]);
-    assert.equal(receipt.retryable, true);
+    assert.ok(receipt.retryable);
     assert.equal(receipt.provider, "base");
     assert.equal(receipt.attempts, 2);
     assert.deepEqual(receipt.errors, [error]);
@@ -370,21 +389,81 @@ describe("RetryTransport", () => {
 
     assert.ok(firstSettled);
     const first = await firstResult;
-    assert.equal(first.done, false);
-    assert.equal(first.value.successful, true);
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
     if (first.value.successful) {
       assert.equal(first.value.messageId, "message-0");
     }
 
     releaseSecond.resolve();
     const second = await iterator.next();
-    assert.equal(second.done, false);
-    assert.equal(second.value.successful, true);
+    assert.ok(!second.done);
+    assert.ok(second.value.successful);
     if (second.value.successful) {
       assert.equal(second.value.messageId, "message-1");
     }
     const done = await iterator.next();
-    assert.equal(done.done, true);
+    assert.ok(done.done);
+  });
+
+  it("surfaces sendMany input errors after yielding ready receipts", async () => {
+    const inputError = new TypeError("Input failed.");
+    const releaseFailure = Promise.withResolvers<void>();
+    async function* messages(): AsyncIterable<Message> {
+      yield message("First");
+      await releaseFailure.promise;
+      throw inputError;
+    }
+    const base = new TrackingTransport((_message, index) =>
+      Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      })
+    );
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const iterator = transport.sendMany(messages())[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
+    if (first.value.successful) {
+      assert.equal(first.value.messageId, "message-0");
+    }
+
+    releaseFailure.resolve();
+
+    await assert.rejects(() => iterator.next(), inputError);
+  });
+
+  it("does not hang when closed with a pending sendMany input pull", async () => {
+    const never = Promise.withResolvers<void>();
+    async function* messages(): AsyncIterable<Message> {
+      yield message("First");
+      await never.promise;
+      yield message("Second");
+    }
+    const base = new TrackingTransport((_message, index) =>
+      Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      })
+    );
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const iterator = transport.sendMany(messages())[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
+
+    const returned = iterator.return?.();
+    assert.ok(returned != null);
+    assert.ok(await settlesWithin(returned, 50));
   });
 
   it("yields completed sendMany receipts while throttling launches", async () => {
@@ -415,21 +494,21 @@ describe("RetryTransport", () => {
 
     assert.ok(firstSettled);
     const first = await firstResult;
-    assert.equal(first.done, false);
-    assert.equal(first.value.successful, true);
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
     if (first.value.successful) {
       assert.equal(first.value.messageId, "message-0");
     }
 
     releaseThrottle.resolve();
     const second = await iterator.next();
-    assert.equal(second.done, false);
-    assert.equal(second.value.successful, true);
+    assert.ok(!second.done);
+    assert.ok(second.value.successful);
     if (second.value.successful) {
       assert.equal(second.value.messageId, "message-1");
     }
     const done = await iterator.next();
-    assert.equal(done.done, true);
+    assert.ok(done.done);
   });
 
   it("refills sendMany concurrency when later messages finish first", async () => {
@@ -494,15 +573,15 @@ describe("RetryTransport", () => {
     releaseFirst.resolve();
 
     const first = await iterator.next();
-    assert.equal(first.done, false);
-    assert.equal(first.value.successful, true);
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
     if (first.value.successful) {
       assert.equal(first.value.messageId, "first");
     }
 
     const second = await iterator.next();
-    assert.equal(second.done, false);
-    assert.equal(second.value.successful, false);
+    assert.ok(!second.done);
+    assert.ok(!second.value.successful);
     if (!second.value.successful) {
       assert.deepEqual(second.value.errorMessages, [
         "The operation was aborted.",
@@ -531,11 +610,12 @@ describe("RetryTransport", () => {
     });
 
     for await (const receipt of transport.sendMany(messages())) {
-      assert.equal(receipt.successful, true);
+      assert.ok(receipt.successful);
       break;
     }
 
-    assert.equal(closed, true);
+    await waitFor(() => closed);
+    assert.ok(closed);
   });
 
   it("cancels pending sendMany launch waits when consumers stop early", async () => {
@@ -568,7 +648,7 @@ describe("RetryTransport", () => {
       message("Second"),
     ])[Symbol.asyncIterator]();
     const first = await iterator.next();
-    assert.equal(first.done, false);
+    assert.ok(!first.done);
     assert.ok(waitStarted);
 
     await iterator.return?.();
@@ -583,8 +663,8 @@ describe("RetryTransport", () => {
 
     await transport[Symbol.asyncDispose]();
 
-    assert.equal(base.asyncDisposed, true);
-    assert.equal(base.disposed, false);
+    assert.ok(base.asyncDisposed);
+    assert.ok(!base.disposed);
   });
 
   it("disposes wrapped sync disposable transports", async () => {
@@ -593,8 +673,8 @@ describe("RetryTransport", () => {
 
     await transport[Symbol.asyncDispose]();
 
-    assert.equal(base.asyncDisposed, false);
-    assert.equal(base.disposed, true);
+    assert.ok(!base.asyncDisposed);
+    assert.ok(base.disposed);
   });
 
   it("prefers wrapped async disposal when both forms are available", async () => {
@@ -606,8 +686,8 @@ describe("RetryTransport", () => {
 
     await transport[Symbol.asyncDispose]();
 
-    assert.equal(base.asyncDisposed, true);
-    assert.equal(base.disposed, false);
+    assert.ok(base.asyncDisposed);
+    assert.ok(!base.disposed);
   });
 });
 

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -6,6 +6,7 @@ import {
   createReceiptError,
   type Message,
   type Receipt,
+  type ReceiptError,
   type Transport,
   type TransportOptions,
 } from "@upyo/core";
@@ -151,9 +152,12 @@ describe("RetryTransport", () => {
     const transport = createRetryTransport(base, {
       maxAttempts: 2,
       wait: () => Promise.resolve(),
-      shouldRetry: (result) => {
-        if (result instanceof Error) errors.push(result);
-        return result instanceof Error && result.name === "AbortError";
+      shouldRetry: (failure) => {
+        if (failure.kind === "error" && failure.error instanceof Error) {
+          errors.push(failure.error);
+          return failure.error.name === "AbortError";
+        }
+        return false;
       },
     });
 
@@ -204,6 +208,60 @@ describe("RetryTransport", () => {
       { name: "AbortError" },
     );
     assert.equal(base.calls, 1);
+  });
+
+  it("preserves custom abort reasons during the default retry wait", async () => {
+    const controller = new AbortController();
+    const reason = new TypeError("Stop retrying.");
+    const base = new SequenceTransport([
+      createFailedReceipt("Service unavailable", {
+        provider: "base",
+        statusCode: 503,
+      }),
+      { successful: true, messageId: "should-not-send" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      backoff: { baseDelayMilliseconds: 1_000 },
+      jitter: false,
+    });
+
+    const sending = transport.send(message(), { signal: controller.signal });
+    controller.abort(reason);
+
+    await assert.rejects(sending, reason);
+    assert.equal(base.calls, 1);
+  });
+
+  it("preserves structured thrown receipt errors", async () => {
+    const error = createReceiptError("Rate limited.", {
+      provider: "base",
+      statusCode: 429,
+      retryAfterMilliseconds: 5_000,
+      providerDetails: { requestId: "req-1" },
+    });
+    const delays: number[] = [];
+    const base = new SequenceTransport([error, error]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      backoff: { maxDelayMilliseconds: 10_000 },
+      jitter: false,
+      wait: (context) => {
+        delays.push(context.delayMilliseconds);
+        return Promise.resolve();
+      },
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 2);
+    assert.deepEqual(delays, [5_000]);
+    assert.equal(receipt.successful, false);
+    assert.deepEqual(receipt.errorMessages, ["Rate limited."]);
+    assert.equal(receipt.retryable, true);
+    assert.equal(receipt.provider, "base");
+    assert.equal(receipt.attempts, 2);
+    assert.deepEqual(receipt.errors, [error]);
   });
 
   it("retries sendMany messages in input order", async () => {
@@ -286,6 +344,92 @@ describe("RetryTransport", () => {
       receipts.map((receipt) => receipt.successful && receipt.messageId),
       ["message-0", "message-1"],
     );
+  });
+
+  it("yields completed sendMany receipts before slow async input", async () => {
+    const releaseSecond = Promise.withResolvers<void>();
+    async function* messages(): AsyncIterable<Message> {
+      yield message("First");
+      await releaseSecond.promise;
+      yield message("Second");
+    }
+    const base = new TrackingTransport((_message, index) =>
+      Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      })
+    );
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const iterator = transport.sendMany(messages())[Symbol.asyncIterator]();
+    const firstResult = iterator.next();
+    const firstSettled = await settlesWithin(firstResult);
+
+    assert.ok(firstSettled);
+    const first = await firstResult;
+    assert.equal(first.done, false);
+    assert.equal(first.value.successful, true);
+    if (first.value.successful) {
+      assert.equal(first.value.messageId, "message-0");
+    }
+
+    releaseSecond.resolve();
+    const second = await iterator.next();
+    assert.equal(second.done, false);
+    assert.equal(second.value.successful, true);
+    if (second.value.successful) {
+      assert.equal(second.value.messageId, "message-1");
+    }
+    const done = await iterator.next();
+    assert.equal(done.done, true);
+  });
+
+  it("yields completed sendMany receipts while throttling launches", async () => {
+    const releaseThrottle = Promise.withResolvers<void>();
+    const base = new TrackingTransport((_message, index) =>
+      Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      })
+    );
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2, intervalMilliseconds: 1_000 },
+      wait: (context) => {
+        if (context.reason === "sendMany-throttle") {
+          return releaseThrottle.promise;
+        }
+        return Promise.resolve();
+      },
+    });
+
+    const iterator = transport.sendMany([
+      message("First"),
+      message("Second"),
+    ])[Symbol.asyncIterator]();
+    const firstResult = iterator.next();
+    const firstSettled = await settlesWithin(firstResult);
+
+    assert.ok(firstSettled);
+    const first = await firstResult;
+    assert.equal(first.done, false);
+    assert.equal(first.value.successful, true);
+    if (first.value.successful) {
+      assert.equal(first.value.messageId, "message-0");
+    }
+
+    releaseThrottle.resolve();
+    const second = await iterator.next();
+    assert.equal(second.done, false);
+    assert.equal(second.value.successful, true);
+    if (second.value.successful) {
+      assert.equal(second.value.messageId, "message-1");
+    }
+    const done = await iterator.next();
+    assert.equal(done.done, true);
   });
 
   it("refills sendMany concurrency when later messages finish first", async () => {
@@ -394,6 +538,45 @@ describe("RetryTransport", () => {
     assert.equal(closed, true);
   });
 
+  it("cancels pending sendMany launch waits when consumers stop early", async () => {
+    const events: string[] = [];
+    let waitStarted = false;
+    let waitAborted = false;
+    const base = new TrackingTransport((_message, index) => {
+      events.push(`start:${index}`);
+      return Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      });
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2, intervalMilliseconds: 1_000 },
+      wait: (_context, signal) => {
+        waitStarted = true;
+        return new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            waitAborted = true;
+            reject(signal.reason);
+          }, { once: true });
+        });
+      },
+    });
+
+    const iterator = transport.sendMany([
+      message("First"),
+      message("Second"),
+    ])[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    assert.equal(first.done, false);
+    assert.ok(waitStarted);
+
+    await iterator.return?.();
+
+    await waitFor(() => waitAborted);
+    assert.deepEqual(events, ["start:0"]);
+  });
+
   it("disposes wrapped async disposable transports", async () => {
     const base = new DisposableTransport({ asyncDisposable: true });
     const transport = createRetryTransport(base);
@@ -444,8 +627,29 @@ async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
   while (!predicate()) {
-    await Promise.resolve();
+    if (Date.now() >= deadline) {
+      assert.fail("Timed out waiting for condition.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+async function settlesWithin<T>(
+  promise: Promise<T>,
+  milliseconds = 10,
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true, () => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), milliseconds);
+      }),
+    ]);
+  } finally {
+    if (timeout != null) clearTimeout(timeout);
   }
 }
 
@@ -457,6 +661,7 @@ function createAbortError(
 
 type SequenceResult =
   | Receipt<"base">
+  | ReceiptError<"base">
   | Error
   | ((message: Message, options?: TransportOptions) => Receipt<"base">);
 
@@ -474,6 +679,7 @@ class SequenceTransport implements Transport<"base"> {
     options?.signal?.throwIfAborted();
     const result = this.results[this.calls++];
     if (result instanceof Error) return Promise.reject(result);
+    if (isReceiptError(result)) return Promise.reject(result);
     if (typeof result === "function") return Promise.resolve(result(message));
     if (result == null) {
       return Promise.resolve({ successful: true, messageId: "fallback" });
@@ -489,6 +695,11 @@ class SequenceTransport implements Transport<"base"> {
       yield await this.send(item, options);
     }
   }
+}
+
+function isReceiptError(value: unknown): value is ReceiptError<"base"> {
+  return typeof value === "object" && value != null && "category" in value &&
+    "retryable" in value && "message" in value;
 }
 
 class TrackingTransport implements Transport<"base"> {

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -102,6 +102,38 @@ describe("RetryTransport", () => {
     assert.deepEqual(delays, [2_000]);
   });
 
+  it("ignores invalid Retry-After metadata", async () => {
+    const invalidRetryAfterValues = [NaN, -1, Infinity];
+
+    for (const retryAfterMilliseconds of invalidRetryAfterValues) {
+      const delays: number[] = [];
+      const base = new SequenceTransport([
+        createFailedReceipt(createReceiptError("Rate limited", {
+          provider: "base",
+          statusCode: 429,
+          retryAfterMilliseconds,
+        })),
+        { successful: true, messageId: "delivered" },
+      ]);
+      const transport = createRetryTransport(base, {
+        maxAttempts: 2,
+        backoff: {
+          baseDelayMilliseconds: 100,
+          maxDelayMilliseconds: 2_000,
+        },
+        jitter: false,
+        wait: (context) => {
+          delays.push(context.delayMilliseconds);
+          return Promise.resolve();
+        },
+      });
+
+      await transport.send(message());
+
+      assert.deepEqual(delays, [100]);
+    }
+  });
+
   it("retries transient thrown errors and converts exhaustion to a receipt", async () => {
     const base = new SequenceTransport([
       new Error("Connection reset by peer"),
@@ -222,6 +254,23 @@ describe("RetryTransport", () => {
       { name: "AbortError" },
     );
     assert.equal(base.calls, 0);
+  });
+
+  it("rejects caller aborts after wrapped sends", async () => {
+    const controller = new AbortController();
+    const reason = new TypeError("Stop after send.");
+    const releaseSend = Promise.withResolvers<void>();
+    const base = new TrackingTransport(async () => {
+      await releaseSend.promise;
+      return { successful: true, messageId: "should-not-deliver" };
+    });
+    const transport = createRetryTransport(base);
+
+    const sending = transport.send(message(), { signal: controller.signal });
+    controller.abort(reason);
+    releaseSend.resolve();
+
+    await assert.rejects(sending, (error) => error === reason);
   });
 
   it("stops retrying when aborted during the retry wait", async () => {
@@ -478,6 +527,42 @@ describe("RetryTransport", () => {
     await assert.rejects(() => iterator.next(), inputError);
   });
 
+  it("rejects pending sendMany input pulls when aborted", async () => {
+    const controller = new AbortController();
+    const reason = new TypeError("Stop reading input.");
+    const releaseSecond = Promise.withResolvers<void>();
+    async function* messages(): AsyncIterable<Message> {
+      yield message("First");
+      await releaseSecond.promise;
+      yield message("Second");
+    }
+    const base = new TrackingTransport((_message, index) =>
+      Promise.resolve({
+        successful: true,
+        messageId: `message-${index}`,
+      })
+    );
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const iterator = transport.sendMany(messages(), {
+      signal: controller.signal,
+    })[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    assert.ok(!first.done);
+    assert.ok(first.value.successful);
+
+    const next = iterator.next();
+    controller.abort(reason);
+
+    await assert.rejects(
+      () => Promise.race([next, rejectAfter(50)]),
+      (error) => error === reason,
+    );
+  });
+
   it("yields queued sendMany receipts before launch errors", async () => {
     const inputError = new TypeError("Input failed.");
     const messages: Iterable<Message> = {
@@ -566,7 +651,10 @@ describe("RetryTransport", () => {
       assert.equal(second.value.messageId, "message-1");
     }
 
-    await assert.rejects(() => iterator.next(), inputError);
+    await assert.rejects(
+      () => iterator.next(),
+      (error) => error === inputError,
+    );
   });
 
   it("does not hang when closed with a pending sendMany input pull", async () => {
@@ -641,6 +729,7 @@ describe("RetryTransport", () => {
     const returned = iterator.return?.();
     assert.ok(returned != null);
     assert.ok(await settlesWithin(returned, 50));
+    await returned;
     await waitFor(() => closed);
 
     assert.ok(closed);
@@ -800,14 +889,16 @@ describe("RetryTransport", () => {
 
   it("cancels pending sendMany launch waits when consumers stop early", async () => {
     const events: string[] = [];
+    const releaseFirst = Promise.withResolvers<void>();
     let waitStarted = false;
     let waitAborted = false;
-    const base = new TrackingTransport((_message, index) => {
+    const base = new TrackingTransport(async (_message, index) => {
       events.push(`start:${index}`);
-      return Promise.resolve({
+      if (index === 0) await releaseFirst.promise;
+      return {
         successful: true,
         messageId: `message-${index}`,
-      });
+      };
     });
     const transport = createRetryTransport(base, {
       maxAttempts: 1,
@@ -827,7 +918,11 @@ describe("RetryTransport", () => {
       message("First"),
       message("Second"),
     ])[Symbol.asyncIterator]();
-    const first = await iterator.next();
+    const firstResult = iterator.next();
+    await waitFor(() => waitStarted);
+    releaseFirst.resolve();
+
+    const first = await firstResult;
     assert.ok(!first.done);
     assert.ok(waitStarted);
 
@@ -911,6 +1006,15 @@ async function settlesWithin<T>(
   } finally {
     if (timeout != null) clearTimeout(timeout);
   }
+}
+
+function rejectAfter(milliseconds: number): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    setTimeout(
+      () => reject(new Error("Timed out waiting for rejection.")),
+      milliseconds,
+    );
+  });
 }
 
 function createAbortError(

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -1,0 +1,568 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createFailedReceipt,
+  createMessage,
+  createReceiptError,
+  type Message,
+  type Receipt,
+  type Transport,
+  type TransportOptions,
+} from "@upyo/core";
+import {
+  createRetryTransport,
+  type DelayContext,
+  RetryTransport,
+} from "./index.ts";
+
+describe("RetryTransport", () => {
+  it("retries retryable failed receipts and returns the later success", async () => {
+    const delays: DelayContext[] = [];
+    const base = new SequenceTransport([
+      createFailedReceipt("Too many requests", {
+        provider: "base",
+        statusCode: 429,
+      }),
+      { successful: true, messageId: "delivered" },
+    ]);
+    const transport = new RetryTransport(base, {
+      maxAttempts: 3,
+      backoff: { baseDelayMilliseconds: 100 },
+      jitter: false,
+      wait: (context) => {
+        delays.push(context);
+        return Promise.resolve();
+      },
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 2);
+    assert.equal(receipt.successful, true);
+    assert.equal(receipt.messageId, "delivered");
+    assert.equal(receipt.provider, "base");
+    assert.equal(receipt.attempts, 2);
+    assert.deepEqual(delays.map((delay) => delay.delayMilliseconds), [100]);
+  });
+
+  it("does not retry permanent failed receipts", async () => {
+    const waits: DelayContext[] = [];
+    const base = new SequenceTransport([
+      createFailedReceipt("Invalid recipient", {
+        provider: "base",
+        category: "validation",
+        retryable: false,
+      }),
+      { successful: true, messageId: "should-not-send" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 3,
+      wait: (context) => {
+        waits.push(context);
+        return Promise.resolve();
+      },
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 1);
+    assert.equal(receipt.successful, false);
+    assert.deepEqual(receipt.errorMessages, ["Invalid recipient"]);
+    assert.equal(receipt.provider, "base");
+    assert.equal(receipt.attempts, 1);
+    assert.equal(waits.length, 0);
+  });
+
+  it("uses capped Retry-After metadata before computed backoff", async () => {
+    const delays: number[] = [];
+    const base = new SequenceTransport([
+      createFailedReceipt(createReceiptError("Rate limited", {
+        provider: "base",
+        statusCode: 429,
+        retryAfterMilliseconds: 5_000,
+      })),
+      { successful: true, messageId: "delivered" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      backoff: {
+        baseDelayMilliseconds: 100,
+        maxDelayMilliseconds: 2_000,
+      },
+      jitter: false,
+      wait: (context) => {
+        delays.push(context.delayMilliseconds);
+        return Promise.resolve();
+      },
+    });
+
+    await transport.send(message());
+
+    assert.deepEqual(delays, [2_000]);
+  });
+
+  it("retries transient thrown errors and converts exhaustion to a receipt", async () => {
+    const base = new SequenceTransport([
+      new Error("Connection reset by peer"),
+      new Error("Connection reset by peer"),
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      jitter: false,
+      wait: () => Promise.resolve(),
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 2);
+    assert.equal(receipt.successful, false);
+    assert.deepEqual(receipt.errorMessages, ["Connection reset by peer"]);
+    assert.equal(receipt.retryable, true);
+    assert.equal(receipt.provider, "base");
+    assert.equal(receipt.attempts, 2);
+    assert.equal(receipt.errors?.[0]?.category, "network");
+  });
+
+  it("retries provider AbortError timeouts", async () => {
+    const base = new SequenceTransport([
+      createAbortError("Request timed out."),
+      { successful: true, messageId: "delivered" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      jitter: false,
+      wait: () => Promise.resolve(),
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 2);
+    assert.equal(receipt.successful, true);
+    assert.equal(receipt.messageId, "delivered");
+    assert.equal(receipt.attempts, 2);
+  });
+
+  it("lets custom retry policy classify provider AbortErrors", async () => {
+    const errors: unknown[] = [];
+    const base = new SequenceTransport([
+      createAbortError(),
+      { successful: true, messageId: "delivered" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      wait: () => Promise.resolve(),
+      shouldRetry: (result) => {
+        if (result instanceof Error) errors.push(result);
+        return result instanceof Error && result.name === "AbortError";
+      },
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 2);
+    assert.equal(receipt.successful, true);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0], base.results[0]);
+  });
+
+  it("does not retry caller cancellation", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const base = new SequenceTransport([
+      { successful: true, messageId: "should-not-send" },
+    ]);
+    const transport = createRetryTransport(base);
+
+    await assert.rejects(
+      () => transport.send(message(), { signal: controller.signal }),
+      { name: "AbortError" },
+    );
+    assert.equal(base.calls, 0);
+  });
+
+  it("stops retrying when aborted during the retry wait", async () => {
+    const controller = new AbortController();
+    const base = new SequenceTransport([
+      createFailedReceipt("Service unavailable", {
+        provider: "base",
+        statusCode: 503,
+      }),
+      { successful: true, messageId: "should-not-send" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      jitter: false,
+      wait: (_context, signal) => {
+        controller.abort();
+        signal?.throwIfAborted();
+        return Promise.resolve();
+      },
+    });
+
+    await assert.rejects(
+      () => transport.send(message(), { signal: controller.signal }),
+      { name: "AbortError" },
+    );
+    assert.equal(base.calls, 1);
+  });
+
+  it("retries sendMany messages in input order", async () => {
+    const base = new SequenceTransport([
+      createFailedReceipt("Temporarily unavailable", {
+        provider: "base",
+        statusCode: 503,
+      }),
+      { successful: true, messageId: "first" },
+      { successful: true, messageId: "second" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      jitter: false,
+      wait: () => Promise.resolve(),
+    });
+
+    const receipts = await collect(transport.sendMany([
+      message("First"),
+      message("Second"),
+    ]));
+
+    assert.equal(base.calls, 3);
+    assert.deepEqual(
+      receipts.map((receipt) => receipt.successful && receipt.messageId),
+      ["first", "second"],
+    );
+  });
+
+  it("limits sendMany concurrency and spaces launches", async () => {
+    const events: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const releaseFirst = Promise.withResolvers<void>();
+    const releaseSecond = Promise.withResolvers<void>();
+    const releases = [releaseFirst.promise, releaseSecond.promise];
+    const base = new TrackingTransport(async (_message, index) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      events.push(`start:${index}`);
+      await releases[index];
+      active--;
+      events.push(`finish:${index}`);
+      return { successful: true, messageId: `message-${index}` };
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: {
+        maxConcurrent: 2,
+        intervalMilliseconds: 25,
+      },
+      wait: (context) => {
+        events.push(`wait:${context.delayMilliseconds}`);
+        return Promise.resolve();
+      },
+    });
+
+    const receiptsPromise = collect(transport.sendMany([
+      message("First"),
+      message("Second"),
+    ]));
+
+    releaseSecond.resolve();
+    await waitFor(() => events.includes("finish:1"));
+    assert.deepEqual(events, ["start:0", "wait:25", "start:1", "finish:1"]);
+
+    releaseFirst.resolve();
+
+    const receipts = await receiptsPromise;
+
+    assert.deepEqual(events, [
+      "start:0",
+      "wait:25",
+      "start:1",
+      "finish:1",
+      "finish:0",
+    ]);
+    assert.equal(maxActive, 2);
+    assert.deepEqual(
+      receipts.map((receipt) => receipt.successful && receipt.messageId),
+      ["message-0", "message-1"],
+    );
+  });
+
+  it("refills sendMany concurrency when later messages finish first", async () => {
+    const events: string[] = [];
+    const releaseFirst = Promise.withResolvers<void>();
+    const base = new TrackingTransport(async (_message, index) => {
+      events.push(`start:${index}`);
+      if (index === 0) await releaseFirst.promise;
+      events.push(`finish:${index}`);
+      return { successful: true, messageId: `message-${index}` };
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const receiptsPromise = collect(transport.sendMany([
+      message("First"),
+      message("Second"),
+      message("Third"),
+    ]));
+
+    await waitFor(() => events.includes("finish:1"));
+    await waitFor(() => events.includes("start:2"));
+    assert.deepEqual(events, [
+      "start:0",
+      "start:1",
+      "finish:1",
+      "start:2",
+      "finish:2",
+    ]);
+
+    releaseFirst.resolve();
+
+    const receipts = await receiptsPromise;
+
+    assert.deepEqual(
+      receipts.map((receipt) => receipt.successful && receipt.messageId),
+      ["message-0", "message-1", "message-2"],
+    );
+  });
+
+  it("keeps later sendMany thrown failures ordered", async () => {
+    const releaseFirst = Promise.withResolvers<void>();
+    const base = new TrackingTransport(async (_message, index) => {
+      if (index === 1) throw createAbortError();
+      await releaseFirst.promise;
+      return { successful: true, messageId: "first" };
+    });
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 2 },
+    });
+
+    const receipts = transport.sendMany([
+      message("First"),
+      message("Second"),
+    ]);
+    const iterator = receipts[Symbol.asyncIterator]();
+
+    await Promise.resolve();
+    releaseFirst.resolve();
+
+    const first = await iterator.next();
+    assert.equal(first.done, false);
+    assert.equal(first.value.successful, true);
+    if (first.value.successful) {
+      assert.equal(first.value.messageId, "first");
+    }
+
+    const second = await iterator.next();
+    assert.equal(second.done, false);
+    assert.equal(second.value.successful, false);
+    if (!second.value.successful) {
+      assert.deepEqual(second.value.errorMessages, [
+        "The operation was aborted.",
+      ]);
+      assert.equal(second.value.attempts, 1);
+    }
+  });
+
+  it("closes sendMany input iterators when consumers stop early", async () => {
+    let closed = false;
+    async function* messages(): AsyncIterable<Message> {
+      try {
+        yield message("First");
+        yield message("Second");
+      } finally {
+        closed = true;
+      }
+    }
+    const base = new SequenceTransport([
+      { successful: true, messageId: "first" },
+      { successful: true, messageId: "second" },
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 1,
+      sendMany: { maxConcurrent: 1 },
+    });
+
+    for await (const receipt of transport.sendMany(messages())) {
+      assert.equal(receipt.successful, true);
+      break;
+    }
+
+    assert.equal(closed, true);
+  });
+
+  it("disposes wrapped async disposable transports", async () => {
+    const base = new DisposableTransport({ asyncDisposable: true });
+    const transport = createRetryTransport(base);
+
+    await transport[Symbol.asyncDispose]();
+
+    assert.equal(base.asyncDisposed, true);
+    assert.equal(base.disposed, false);
+  });
+
+  it("disposes wrapped sync disposable transports", async () => {
+    const base = new DisposableTransport({ disposable: true });
+    const transport = createRetryTransport(base);
+
+    await transport[Symbol.asyncDispose]();
+
+    assert.equal(base.asyncDisposed, false);
+    assert.equal(base.disposed, true);
+  });
+
+  it("prefers wrapped async disposal when both forms are available", async () => {
+    const base = new DisposableTransport({
+      asyncDisposable: true,
+      disposable: true,
+    });
+    const transport = createRetryTransport(base);
+
+    await transport[Symbol.asyncDispose]();
+
+    assert.equal(base.asyncDisposed, true);
+    assert.equal(base.disposed, false);
+  });
+});
+
+function message(subject = "Hello"): Message {
+  return createMessage({
+    from: "sender@example.com",
+    to: "recipient@example.com",
+    subject,
+    content: { text: "Hello" },
+  });
+}
+
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of values) result.push(value);
+  return result;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  while (!predicate()) {
+    await Promise.resolve();
+  }
+}
+
+function createAbortError(
+  message = "The operation was aborted.",
+): DOMException {
+  return new DOMException(message, "AbortError");
+}
+
+type SequenceResult =
+  | Receipt<"base">
+  | Error
+  | ((message: Message, options?: TransportOptions) => Receipt<"base">);
+
+class SequenceTransport implements Transport<"base"> {
+  readonly id = "base";
+  calls = 0;
+
+  constructor(readonly results: readonly SequenceResult[]) {
+  }
+
+  send(
+    message: Message,
+    options?: TransportOptions,
+  ): Promise<Receipt<"base">> {
+    options?.signal?.throwIfAborted();
+    const result = this.results[this.calls++];
+    if (result instanceof Error) return Promise.reject(result);
+    if (typeof result === "function") return Promise.resolve(result(message));
+    if (result == null) {
+      return Promise.resolve({ successful: true, messageId: "fallback" });
+    }
+    return Promise.resolve(result);
+  }
+
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt<"base">> {
+    for await (const item of messages) {
+      yield await this.send(item, options);
+    }
+  }
+}
+
+class TrackingTransport implements Transport<"base"> {
+  readonly id = "base";
+  private calls = 0;
+
+  constructor(
+    private readonly handler: (
+      message: Message,
+      index: number,
+      options?: TransportOptions,
+    ) => Promise<Receipt<"base">>,
+  ) {
+  }
+
+  send(
+    message: Message,
+    options?: TransportOptions,
+  ): Promise<Receipt<"base">> {
+    const index = this.calls++;
+    return this.handler(message, index, options);
+  }
+
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt<"base">> {
+    for await (const item of messages) {
+      yield await this.send(item, options);
+    }
+  }
+}
+
+class DisposableTransport implements Transport<"base"> {
+  readonly id = "base";
+  asyncDisposed = false;
+  disposed = false;
+
+  constructor(
+    private readonly options: {
+      readonly asyncDisposable?: boolean;
+      readonly disposable?: boolean;
+    },
+  ) {
+    if (options.asyncDisposable) {
+      Object.defineProperty(this, Symbol.asyncDispose, {
+        value: () => {
+          this.asyncDisposed = true;
+          return Promise.resolve();
+        },
+      });
+    }
+    if (options.disposable) {
+      Object.defineProperty(this, Symbol.dispose, {
+        value: () => {
+          this.disposed = true;
+        },
+      });
+    }
+  }
+
+  send(
+    _message: Message,
+    _options?: TransportOptions,
+  ): Promise<Receipt<"base">> {
+    return Promise.resolve({ successful: true, messageId: "disposed" });
+  }
+
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt<"base">> {
+    for await (const item of messages) {
+      yield await this.send(item, options);
+    }
+  }
+}

--- a/packages/retry/src/retry-transport.test.ts
+++ b/packages/retry/src/retry-transport.test.ts
@@ -162,6 +162,27 @@ describe("RetryTransport", () => {
     assert.equal(receipt.attempts, 2);
   });
 
+  it("preserves retryable metadata for exhausted provider AbortErrors", async () => {
+    const base = new SequenceTransport([
+      createAbortError(),
+      createAbortError(),
+    ]);
+    const transport = createRetryTransport(base, {
+      maxAttempts: 2,
+      jitter: false,
+      wait: () => Promise.resolve(),
+    });
+
+    const receipt = await transport.send(message());
+
+    assert.equal(base.calls, 2);
+    assert.ok(!receipt.successful);
+    assert.ok(receipt.retryable);
+    assert.equal(receipt.errors?.[0]?.category, "timeout");
+    assert.equal(receipt.errors?.[0]?.code, "timeout");
+    assert.equal(receipt.attempts, 2);
+  });
+
   it("lets custom retry policy classify provider AbortErrors", async () => {
     const errors: unknown[] = [];
     const base = new SequenceTransport([

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -209,8 +209,6 @@ export class RetryTransport<TProviderId extends string = string>
         launchPromise != null ||
         !inputDone
       ) {
-        if (hasLaunchError) throw launchError;
-
         while (completed.has(nextYieldIndex)) {
           const result = completed.get(nextYieldIndex);
           completed.delete(nextYieldIndex);
@@ -220,6 +218,8 @@ export class RetryTransport<TProviderId extends string = string>
           nextYieldIndex++;
           startLaunch();
         }
+
+        if (hasLaunchError) throw launchError;
 
         startLaunch();
         if (inFlight.size <= 0 && launchPromise == null) break;

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -187,6 +187,7 @@ export class RetryTransport<TProviderId extends string = string>
       if (
         launchPromise != null ||
         inputDone ||
+        hasLaunchError ||
         inFlight.size >= this.config.sendMany.maxConcurrent
       ) return;
 
@@ -219,7 +220,7 @@ export class RetryTransport<TProviderId extends string = string>
           startLaunch();
         }
 
-        if (hasLaunchError) throw launchError;
+        if (hasLaunchError && inFlight.size <= 0) throw launchError;
 
         startLaunch();
         if (inFlight.size <= 0 && launchPromise == null) break;
@@ -263,6 +264,8 @@ export class RetryTransport<TProviderId extends string = string>
   /**
    * Disposes the wrapped transport when it supports disposal.
    *
+   * @throws {unknown} If the wrapped transport's async or sync disposal hook
+   *   throws or rejects.
    * @since 0.5.0
    */
   async [Symbol.asyncDispose](): Promise<void> {

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -1,5 +1,6 @@
 import {
   classifyReceiptError,
+  combineSignals,
   createFailedReceipt,
   createReceiptError,
   type Message,
@@ -102,7 +103,10 @@ export class RetryTransport<TProviderId extends string = string>
           attempt,
           nextAttempt: attempt + 1,
           maxAttempts: this.config.maxAttempts,
-          delayMilliseconds: this.calculateDelay(attempt),
+          delayMilliseconds: this.calculateDelay(
+            attempt,
+            toReceiptError<TProviderId>(error),
+          ),
           error,
           reason: "retry",
         }, options?.signal);
@@ -132,20 +136,30 @@ export class RetryTransport<TProviderId extends string = string>
     let inputDone = false;
     let nextLaunchIndex = 0;
     let nextYieldIndex = 0;
+    let launchPromise: Promise<void> | undefined;
+    let closed = false;
+    const controller = new AbortController();
+    const combinedSignal = combineSignals(controller.signal, options?.signal);
+    const sendOptions: TransportOptions = {
+      ...options,
+      signal: combinedSignal.signal,
+    };
 
     const launchNext = async (): Promise<void> => {
       if (inputDone) return;
-      options?.signal?.throwIfAborted();
+      combinedSignal.signal.throwIfAborted();
 
       const next = await iterator.next();
+      if (closed) return;
       if (next.done) {
         inputDone = true;
         return;
       }
 
       const index = nextLaunchIndex++;
-      if (index > 0) await this.waitBetweenSendMany(options?.signal);
-      const promise = this.send(next.value, options).then(
+      if (index > 0) await this.waitBetweenSendMany(combinedSignal.signal);
+      if (closed) return;
+      const promise = this.send(next.value, sendOptions).then(
         (receipt): SendManyResult<TProviderId> => ({
           index,
           successful: true,
@@ -160,18 +174,27 @@ export class RetryTransport<TProviderId extends string = string>
       inFlight.set(index, promise);
     };
 
-    const launchAvailable = async (): Promise<void> => {
-      while (
-        !inputDone && inFlight.size < this.config.sendMany.maxConcurrent
-      ) {
-        await launchNext();
-      }
+    const startLaunch = (): void => {
+      if (
+        launchPromise != null ||
+        inputDone ||
+        inFlight.size >= this.config.sendMany.maxConcurrent
+      ) return;
+
+      launchPromise = launchNext().finally(() => {
+        launchPromise = undefined;
+      });
     };
 
     try {
-      await launchAvailable();
+      startLaunch();
 
-      while (inFlight.size > 0 || completed.has(nextYieldIndex)) {
+      while (
+        inFlight.size > 0 ||
+        completed.has(nextYieldIndex) ||
+        launchPromise != null ||
+        !inputDone
+      ) {
         while (completed.has(nextYieldIndex)) {
           const result = completed.get(nextYieldIndex);
           completed.delete(nextYieldIndex);
@@ -179,18 +202,35 @@ export class RetryTransport<TProviderId extends string = string>
           if (!result.successful) throw result.error;
           yield result.receipt;
           nextYieldIndex++;
-          await launchAvailable();
+          startLaunch();
         }
 
-        if (inFlight.size <= 0) break;
+        startLaunch();
+        if (inFlight.size <= 0 && launchPromise == null) break;
 
-        const result = await Promise.race(inFlight.values());
+        const launch = launchPromise?.then((): LaunchResult => ({
+          launched: true,
+        }));
+        const result = await Promise.race([
+          ...inFlight.values(),
+          ...(launch == null ? [] : [launch]),
+        ]);
+        if ("launched" in result) continue;
         inFlight.delete(result.index);
         completed.set(result.index, result);
-        if (result.index !== nextYieldIndex) await launchAvailable();
+        startLaunch();
       }
     } finally {
-      if (!inputDone) await iterator.return?.();
+      closed = true;
+      controller.abort(
+        new DOMException("The operation was aborted.", "AbortError"),
+      );
+      launchPromise?.catch(() => {});
+      try {
+        if (!inputDone) await iterator.return?.();
+      } finally {
+        combinedSignal.cleanup();
+      }
     }
   }
 
@@ -239,14 +279,22 @@ export class RetryTransport<TProviderId extends string = string>
     receipt: Receipt<TProviderId> & { readonly successful: false },
   ): boolean {
     if (this.config.shouldRetry != null) {
-      return this.config.shouldRetry(receipt);
+      return this.config.shouldRetry({ kind: "receipt", receipt });
     }
     if (receipt.retryable != null) return receipt.retryable;
     return this.hasRetryableError(receipt.errors);
   }
 
   private shouldRetryError(error: unknown): boolean {
-    if (this.config.shouldRetry != null) return this.config.shouldRetry(error);
+    const receiptError = toReceiptError<TProviderId>(error);
+    if (this.config.shouldRetry != null) {
+      return this.config.shouldRetry({
+        kind: "error",
+        error,
+        receiptError,
+      });
+    }
+    if (receiptError != null) return receiptError.retryable;
     return classifyReceiptError(error).retryable;
   }
 
@@ -258,9 +306,11 @@ export class RetryTransport<TProviderId extends string = string>
 
   private calculateDelay(
     attempt: number,
-    receipt?: Receipt<TProviderId> & { readonly successful: false },
+    failure?:
+      | (Receipt<TProviderId> & { readonly successful: false })
+      | ReceiptError<TProviderId>,
   ): number {
-    const retryAfterMilliseconds = getRetryAfterMilliseconds(receipt);
+    const retryAfterMilliseconds = getRetryAfterMilliseconds(failure);
     const cappedRetryAfter = retryAfterMilliseconds == null
       ? undefined
       : Math.min(
@@ -306,6 +356,14 @@ export class RetryTransport<TProviderId extends string = string>
     error: unknown,
     attempts: number,
   ): Receipt<TProviderId> & { readonly successful: false } {
+    const receiptError = toReceiptError<TProviderId>(error);
+    if (receiptError != null) {
+      return createFailedReceipt(receiptError, {
+        provider: receiptError.provider ?? this.id,
+        attempts,
+      });
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     const classification = classifyReceiptError(error);
     return createFailedReceipt(
@@ -335,6 +393,10 @@ type SendManyResult<TProviderId extends string> =
     readonly error: unknown;
   };
 
+interface LaunchResult {
+  readonly launched: true;
+}
+
 /**
  * Creates a retrying transport around another transport.
  *
@@ -352,16 +414,36 @@ export function createRetryTransport<TProviderId extends string = string>(
 }
 
 function getRetryAfterMilliseconds<TProviderId extends string>(
-  receipt: (Receipt<TProviderId> & { readonly successful: false }) | undefined,
+  failure:
+    | (Receipt<TProviderId> & { readonly successful: false })
+    | ReceiptError<TProviderId>
+    | undefined,
 ): number | undefined {
-  const receiptDelay = receipt?.errors
-    ?.map((error) => error.retryAfterMilliseconds)
-    .find((delay) => delay != null);
-  return receiptDelay;
+  if (failure == null) return undefined;
+  if (isReceiptError(failure)) return failure.retryAfterMilliseconds;
+  return failure.errors?.find((error) => error.retryAfterMilliseconds != null)
+    ?.retryAfterMilliseconds;
 }
 
 async function* toAsyncIterator<T>(
   values: Iterable<T> | AsyncIterable<T>,
 ): AsyncIterator<T> {
   for await (const value of values) yield value;
+}
+
+function toReceiptError<TProviderId extends string>(
+  value: unknown,
+): ReceiptError<TProviderId> | undefined {
+  return isReceiptError<TProviderId>(value) ? value : undefined;
+}
+
+function isReceiptError<TProviderId extends string>(
+  value: unknown,
+): value is ReceiptError<TProviderId> {
+  return typeof value === "object" && value != null &&
+    typeof (value as { readonly message?: unknown }).message === "string" &&
+    typeof (value as { readonly code?: unknown }).code === "string" &&
+    typeof (value as { readonly category?: unknown }).category === "string" &&
+    typeof (value as { readonly retryable?: unknown }).retryable ===
+      "boolean";
 }

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -1,0 +1,367 @@
+import {
+  classifyReceiptError,
+  createFailedReceipt,
+  createReceiptError,
+  type Message,
+  type Receipt,
+  type ReceiptError,
+  type Transport,
+  type TransportOptions,
+} from "@upyo/core";
+import {
+  createRetryConfig,
+  type DelayContext,
+  type ResolvedRetryConfig,
+  type RetryConfig,
+} from "./config.ts";
+
+/**
+ * Transport decorator that retries transient delivery failures.
+ *
+ * @since 0.5.0
+ */
+export class RetryTransport<TProviderId extends string = string>
+  implements Transport<TProviderId>, AsyncDisposable {
+  readonly id: TProviderId;
+
+  /**
+   * Resolved retry configuration.
+   */
+  readonly config: ResolvedRetryConfig<TProviderId>;
+
+  private readonly wrappedTransport: Transport<TProviderId>;
+
+  /**
+   * Creates a retrying transport around another transport.
+   *
+   * @param transport The transport to wrap.
+   * @param config Retry configuration.
+   * @throws {RangeError} If retry configuration is invalid.
+   */
+  constructor(
+    transport: Transport<TProviderId>,
+    config: RetryConfig<TProviderId> = {},
+  ) {
+    this.wrappedTransport = transport;
+    this.id = transport.id;
+    this.config = createRetryConfig(config);
+  }
+
+  /**
+   * Sends one message, retrying retryable failures.
+   *
+   * @param message The message to send.
+   * @param options Optional transport options.
+   * @returns The final delivery receipt.
+   * @throws {DOMException} If the operation is aborted.
+   */
+  async send(
+    message: Message,
+    options?: TransportOptions,
+  ): Promise<Receipt<TProviderId>> {
+    options?.signal?.throwIfAborted();
+
+    let lastThrownError: unknown;
+    for (let attempt = 1; attempt <= this.config.maxAttempts; attempt++) {
+      options?.signal?.throwIfAborted();
+
+      try {
+        const receipt = await this.wrappedTransport.send(message, options);
+        if (receipt.successful) {
+          return this.withSuccessMetadata(receipt, attempt);
+        }
+
+        const failedReceipt = this.withFailureMetadata(receipt, attempt);
+        if (
+          attempt >= this.config.maxAttempts ||
+          !this.shouldRetryReceipt(failedReceipt)
+        ) {
+          return failedReceipt;
+        }
+
+        await this.waitBeforeRetry({
+          attempt,
+          nextAttempt: attempt + 1,
+          maxAttempts: this.config.maxAttempts,
+          delayMilliseconds: this.calculateDelay(attempt, failedReceipt),
+          receipt: failedReceipt,
+          reason: "retry",
+        }, options?.signal);
+      } catch (error) {
+        options?.signal?.throwIfAborted();
+
+        lastThrownError = error;
+        if (
+          attempt >= this.config.maxAttempts ||
+          !this.shouldRetryError(error)
+        ) {
+          return this.createThrownFailure(error, attempt);
+        }
+
+        await this.waitBeforeRetry({
+          attempt,
+          nextAttempt: attempt + 1,
+          maxAttempts: this.config.maxAttempts,
+          delayMilliseconds: this.calculateDelay(attempt),
+          error,
+          reason: "retry",
+        }, options?.signal);
+      }
+    }
+
+    return this.createThrownFailure(lastThrownError, this.config.maxAttempts);
+  }
+
+  /**
+   * Sends messages with per-message retry behavior.
+   *
+   * Receipts are yielded in the same order as input messages.
+   *
+   * @param messages Messages to send.
+   * @param options Optional transport options.
+   * @returns An async iterable of receipts.
+   * @throws {DOMException} If the operation is aborted.
+   */
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt<TProviderId>> {
+    const iterator = toAsyncIterator(messages);
+    const inFlight = new Map<number, Promise<SendManyResult<TProviderId>>>();
+    const completed = new Map<number, SendManyResult<TProviderId>>();
+    let inputDone = false;
+    let nextLaunchIndex = 0;
+    let nextYieldIndex = 0;
+
+    const launchNext = async (): Promise<void> => {
+      if (inputDone) return;
+      options?.signal?.throwIfAborted();
+
+      const next = await iterator.next();
+      if (next.done) {
+        inputDone = true;
+        return;
+      }
+
+      const index = nextLaunchIndex++;
+      if (index > 0) await this.waitBetweenSendMany(options?.signal);
+      const promise = this.send(next.value, options).then(
+        (receipt): SendManyResult<TProviderId> => ({
+          index,
+          successful: true,
+          receipt,
+        }),
+        (error): SendManyResult<TProviderId> => ({
+          index,
+          successful: false,
+          error,
+        }),
+      );
+      inFlight.set(index, promise);
+    };
+
+    const launchAvailable = async (): Promise<void> => {
+      while (
+        !inputDone && inFlight.size < this.config.sendMany.maxConcurrent
+      ) {
+        await launchNext();
+      }
+    };
+
+    try {
+      await launchAvailable();
+
+      while (inFlight.size > 0 || completed.has(nextYieldIndex)) {
+        while (completed.has(nextYieldIndex)) {
+          const result = completed.get(nextYieldIndex);
+          completed.delete(nextYieldIndex);
+          if (result == null) break;
+          if (!result.successful) throw result.error;
+          yield result.receipt;
+          nextYieldIndex++;
+          await launchAvailable();
+        }
+
+        if (inFlight.size <= 0) break;
+
+        const result = await Promise.race(inFlight.values());
+        inFlight.delete(result.index);
+        completed.set(result.index, result);
+        if (result.index !== nextYieldIndex) await launchAvailable();
+      }
+    } finally {
+      if (!inputDone) await iterator.return?.();
+    }
+  }
+
+  /**
+   * Disposes the wrapped transport when it supports disposal.
+   *
+   * @since 0.5.0
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    const asyncDisposable = this.wrappedTransport as Partial<AsyncDisposable>;
+    const asyncDispose = asyncDisposable[Symbol.asyncDispose];
+    if (typeof asyncDispose === "function") {
+      await asyncDispose.call(asyncDisposable);
+      return;
+    }
+
+    const disposable = this.wrappedTransport as Partial<Disposable>;
+    const dispose = disposable[Symbol.dispose];
+    if (typeof dispose === "function") dispose.call(disposable);
+  }
+
+  private withSuccessMetadata(
+    receipt: Receipt<TProviderId> & { readonly successful: true },
+    attempts: number,
+  ): Receipt<TProviderId> & { readonly successful: true } {
+    return {
+      ...receipt,
+      provider: receipt.provider ?? this.id,
+      attempts,
+    };
+  }
+
+  private withFailureMetadata(
+    receipt: Receipt<TProviderId> & { readonly successful: false },
+    attempts: number,
+  ): Receipt<TProviderId> & { readonly successful: false } {
+    return {
+      ...receipt,
+      provider: receipt.provider ?? this.id,
+      retryable: receipt.retryable ?? this.hasRetryableError(receipt.errors),
+      attempts,
+    };
+  }
+
+  private shouldRetryReceipt(
+    receipt: Receipt<TProviderId> & { readonly successful: false },
+  ): boolean {
+    if (this.config.shouldRetry != null) {
+      return this.config.shouldRetry(receipt);
+    }
+    if (receipt.retryable != null) return receipt.retryable;
+    return this.hasRetryableError(receipt.errors);
+  }
+
+  private shouldRetryError(error: unknown): boolean {
+    if (this.config.shouldRetry != null) return this.config.shouldRetry(error);
+    return classifyReceiptError(error).retryable;
+  }
+
+  private hasRetryableError(
+    errors: readonly ReceiptError<TProviderId>[] | undefined,
+  ): boolean {
+    return errors?.some((error) => error.retryable) ?? false;
+  }
+
+  private calculateDelay(
+    attempt: number,
+    receipt?: Receipt<TProviderId> & { readonly successful: false },
+  ): number {
+    const retryAfterMilliseconds = getRetryAfterMilliseconds(receipt);
+    const cappedRetryAfter = retryAfterMilliseconds == null
+      ? undefined
+      : Math.min(
+        retryAfterMilliseconds,
+        this.config.backoff.maxDelayMilliseconds,
+      );
+
+    if (cappedRetryAfter != null) return cappedRetryAfter;
+
+    const computedDelay = Math.min(
+      this.config.backoff.baseDelayMilliseconds *
+        Math.pow(this.config.backoff.factor, attempt - 1),
+      this.config.backoff.maxDelayMilliseconds,
+    );
+
+    if (this.config.jitter === false || this.config.jitter === "none") {
+      return computedDelay;
+    }
+
+    return Math.floor(this.config.random() * computedDelay);
+  }
+
+  private waitBeforeRetry(
+    context: DelayContext<TProviderId>,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    return this.config.wait(context, signal);
+  }
+
+  private waitBetweenSendMany(signal?: AbortSignal): Promise<void> {
+    const delayMilliseconds = this.config.sendMany.intervalMilliseconds;
+    if (delayMilliseconds <= 0) return Promise.resolve();
+    return this.config.wait({
+      attempt: 0,
+      nextAttempt: 0,
+      maxAttempts: this.config.maxAttempts,
+      delayMilliseconds,
+      reason: "sendMany-throttle",
+    }, signal);
+  }
+
+  private createThrownFailure(
+    error: unknown,
+    attempts: number,
+  ): Receipt<TProviderId> & { readonly successful: false } {
+    const message = error instanceof Error ? error.message : String(error);
+    const classification = classifyReceiptError(error);
+    return createFailedReceipt(
+      createReceiptError(message, {
+        provider: this.id,
+        category: classification.category,
+        code: classification.code,
+        retryable: classification.retryable,
+      }),
+      {
+        provider: this.id,
+        attempts,
+      },
+    );
+  }
+}
+
+type SendManyResult<TProviderId extends string> =
+  | {
+    readonly index: number;
+    readonly successful: true;
+    readonly receipt: Receipt<TProviderId>;
+  }
+  | {
+    readonly index: number;
+    readonly successful: false;
+    readonly error: unknown;
+  };
+
+/**
+ * Creates a retrying transport around another transport.
+ *
+ * @param baseTransport The transport to wrap.
+ * @param config Retry configuration.
+ * @returns A retrying transport decorator.
+ * @throws {RangeError} If retry configuration is invalid.
+ * @since 0.5.0
+ */
+export function createRetryTransport<TProviderId extends string = string>(
+  baseTransport: Transport<TProviderId>,
+  config: RetryConfig<TProviderId> = {},
+): RetryTransport<TProviderId> {
+  return new RetryTransport(baseTransport, config);
+}
+
+function getRetryAfterMilliseconds<TProviderId extends string>(
+  receipt: (Receipt<TProviderId> & { readonly successful: false }) | undefined,
+): number | undefined {
+  const receiptDelay = receipt?.errors
+    ?.map((error) => error.retryAfterMilliseconds)
+    .find((delay) => delay != null);
+  return receiptDelay;
+}
+
+async function* toAsyncIterator<T>(
+  values: Iterable<T> | AsyncIterable<T>,
+): AsyncIterator<T> {
+  for await (const value of values) yield value;
+}

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -397,7 +397,13 @@ export class RetryTransport<TProviderId extends string = string>
     }
 
     const message = error instanceof Error ? error.message : String(error);
-    const classification = classifyReceiptError(error);
+    const classification = error instanceof Error && error.name === "AbortError"
+      ? {
+        category: "timeout" as const,
+        code: "timeout",
+        retryable: true,
+      }
+      : classifyReceiptError(error);
     return createFailedReceipt(
       createReceiptError(message, {
         provider: this.id,

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -137,6 +137,9 @@ export class RetryTransport<TProviderId extends string = string>
     let nextLaunchIndex = 0;
     let nextYieldIndex = 0;
     let launchPromise: Promise<void> | undefined;
+    let launchError: unknown;
+    let hasLaunchError = false;
+    let pullingInput = false;
     let closed = false;
     const controller = new AbortController();
     const combinedSignal = combineSignals(controller.signal, options?.signal);
@@ -149,7 +152,13 @@ export class RetryTransport<TProviderId extends string = string>
       if (inputDone) return;
       combinedSignal.signal.throwIfAborted();
 
-      const next = await iterator.next();
+      pullingInput = true;
+      let next: IteratorResult<Message>;
+      try {
+        next = await iterator.next();
+      } finally {
+        pullingInput = false;
+      }
       if (closed) return;
       if (next.done) {
         inputDone = true;
@@ -181,9 +190,14 @@ export class RetryTransport<TProviderId extends string = string>
         inFlight.size >= this.config.sendMany.maxConcurrent
       ) return;
 
-      launchPromise = launchNext().finally(() => {
-        launchPromise = undefined;
-      });
+      launchPromise = launchNext()
+        .catch((error) => {
+          launchError = error;
+          hasLaunchError = true;
+        })
+        .finally(() => {
+          launchPromise = undefined;
+        });
     };
 
     try {
@@ -195,6 +209,8 @@ export class RetryTransport<TProviderId extends string = string>
         launchPromise != null ||
         !inputDone
       ) {
+        if (hasLaunchError) throw launchError;
+
         while (completed.has(nextYieldIndex)) {
           const result = completed.get(nextYieldIndex);
           completed.delete(nextYieldIndex);
@@ -220,6 +236,7 @@ export class RetryTransport<TProviderId extends string = string>
         completed.set(result.index, result);
         startLaunch();
       }
+      if (hasLaunchError) throw launchError;
     } finally {
       closed = true;
       controller.abort(
@@ -227,7 +244,16 @@ export class RetryTransport<TProviderId extends string = string>
       );
       launchPromise?.catch(() => {});
       try {
-        if (!inputDone) await iterator.return?.();
+        const closeIterator = async (): Promise<void> => {
+          if (!inputDone) await iterator.return?.();
+        };
+        if (pullingInput) {
+          launchPromise?.finally(() => {
+            void closeIterator().catch(() => {});
+          });
+        } else {
+          await closeIterator();
+        }
       } finally {
         combinedSignal.cleanup();
       }
@@ -278,8 +304,9 @@ export class RetryTransport<TProviderId extends string = string>
   private shouldRetryReceipt(
     receipt: Receipt<TProviderId> & { readonly successful: false },
   ): boolean {
-    if (this.config.shouldRetry != null) {
-      return this.config.shouldRetry({ kind: "receipt", receipt });
+    const shouldRetry = this.config.shouldRetry;
+    if (shouldRetry != null) {
+      return shouldRetry({ kind: "receipt", receipt });
     }
     if (receipt.retryable != null) return receipt.retryable;
     return this.hasRetryableError(receipt.errors);
@@ -287,14 +314,16 @@ export class RetryTransport<TProviderId extends string = string>
 
   private shouldRetryError(error: unknown): boolean {
     const receiptError = toReceiptError<TProviderId>(error);
-    if (this.config.shouldRetry != null) {
-      return this.config.shouldRetry({
+    const shouldRetry = this.config.shouldRetry;
+    if (shouldRetry != null) {
+      return shouldRetry({
         kind: "error",
         error,
         receiptError,
       });
     }
     if (receiptError != null) return receiptError.retryable;
+    if (error instanceof Error && error.name === "AbortError") return true;
     return classifyReceiptError(error).retryable;
   }
 
@@ -330,20 +359,23 @@ export class RetryTransport<TProviderId extends string = string>
       return computedDelay;
     }
 
-    return Math.floor(this.config.random() * computedDelay);
+    const random = this.config.random;
+    return Math.floor(random() * computedDelay);
   }
 
   private waitBeforeRetry(
     context: DelayContext<TProviderId>,
     signal?: AbortSignal,
   ): Promise<void> {
-    return this.config.wait(context, signal);
+    const wait = this.config.wait;
+    return wait(context, signal);
   }
 
   private waitBetweenSendMany(signal?: AbortSignal): Promise<void> {
     const delayMilliseconds = this.config.sendMany.intervalMilliseconds;
     if (delayMilliseconds <= 0) return Promise.resolve();
-    return this.config.wait({
+    const wait = this.config.wait;
+    return wait({
       attempt: 0,
       nextAttempt: 0,
       maxAttempts: this.config.maxAttempts,

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -245,15 +245,14 @@ export class RetryTransport<TProviderId extends string = string>
       );
       launchPromise?.catch(() => {});
       try {
-        const closeIterator = async (): Promise<void> => {
-          if (!inputDone) await iterator.return?.();
-        };
+        const closeIterator = ():
+          | Promise<IteratorResult<Message>>
+          | undefined => inputDone ? undefined : iterator.return?.();
+        const closePromise = closeIterator();
         if (pullingInput) {
-          launchPromise?.finally(() => {
-            void closeIterator().catch(() => {});
-          });
+          closePromise?.catch(() => {});
         } else {
-          await closeIterator();
+          await closePromise;
         }
       } finally {
         combinedSignal.cleanup();
@@ -466,10 +465,25 @@ function getRetryAfterMilliseconds<TProviderId extends string>(
     ?.retryAfterMilliseconds;
 }
 
-async function* toAsyncIterator<T>(
+function toAsyncIterator<T>(
   values: Iterable<T> | AsyncIterable<T>,
 ): AsyncIterator<T> {
-  for await (const value of values) yield value;
+  if (Symbol.asyncIterator in values) return values[Symbol.asyncIterator]();
+
+  const iterator = values[Symbol.iterator]();
+  return {
+    next(): Promise<IteratorResult<T>> {
+      return Promise.resolve(iterator.next());
+    },
+    return(value?: unknown): Promise<IteratorResult<T>> {
+      return Promise.resolve(
+        iterator.return?.(value as T) ?? {
+          done: true,
+          value: value as T,
+        },
+      );
+    },
+  };
 }
 
 function toReceiptError<TProviderId extends string>(

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -224,6 +224,8 @@ export class RetryTransport<TProviderId extends string = string>
         launchPromise != null ||
         !inputDone
       ) {
+        combinedSignal.signal.throwIfAborted();
+
         while (completed.has(nextYieldIndex)) {
           const result = completed.get(nextYieldIndex);
           completed.delete(nextYieldIndex);
@@ -242,10 +244,13 @@ export class RetryTransport<TProviderId extends string = string>
         const launch = launchPromise?.then((): LaunchResult => ({
           launched: true,
         }));
-        const result = await Promise.race([
-          ...inFlight.values(),
-          ...(launch == null ? [] : [launch]),
-        ]);
+        const result = await raceWithAbort(
+          Promise.race([
+            ...inFlight.values(),
+            ...(launch == null ? [] : [launch]),
+          ]),
+          combinedSignal.signal,
+        );
         if ("launched" in result) continue;
         inFlight.delete(result.index);
         completed.set(result.index, result);
@@ -366,7 +371,7 @@ export class RetryTransport<TProviderId extends string = string>
     const retryAfterMilliseconds = getRetryAfterMilliseconds(failure);
     const cappedRetryAfter = retryAfterMilliseconds == null ||
         !Number.isFinite(retryAfterMilliseconds) ||
-        retryAfterMilliseconds <= 0
+        retryAfterMilliseconds < 0
       ? undefined
       : Math.min(
         retryAfterMilliseconds,

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -96,6 +96,8 @@ export class RetryTransport<TProviderId extends string = string>
         continue;
       }
 
+      options?.signal?.throwIfAborted();
+
       if (receipt.successful) {
         return this.withSuccessMetadata(receipt, attempt);
       }
@@ -159,12 +161,16 @@ export class RetryTransport<TProviderId extends string = string>
       combinedSignal.signal.throwIfAborted();
 
       pullingInput = true;
-      let next: IteratorResult<Message>;
+      let inputPull: Promise<IteratorResult<Message>>;
       try {
-        next = await iterator.next();
-      } finally {
-        pullingInput = false;
+        inputPull = Promise.resolve(iterator.next());
+      } catch (error) {
+        inputPull = Promise.reject(error);
       }
+      inputPull = inputPull.finally(() => {
+        pullingInput = false;
+      });
+      const next = await raceWithAbort(inputPull, combinedSignal.signal);
       if (closed) return;
       if (next.done) {
         inputDone = true;
@@ -348,7 +354,9 @@ export class RetryTransport<TProviderId extends string = string>
       | ReceiptError<TProviderId>,
   ): number {
     const retryAfterMilliseconds = getRetryAfterMilliseconds(failure);
-    const cappedRetryAfter = retryAfterMilliseconds == null
+    const cappedRetryAfter = retryAfterMilliseconds == null ||
+        !Number.isFinite(retryAfterMilliseconds) ||
+        retryAfterMilliseconds <= 0
       ? undefined
       : Math.min(
         retryAfterMilliseconds,
@@ -478,11 +486,11 @@ function toAsyncIterator<T>(
 
   const iterator = values[Symbol.iterator]();
   return {
-    next(): Promise<IteratorResult<T>> {
-      return Promise.resolve(iterator.next());
+    async next(): Promise<IteratorResult<T>> {
+      return await Promise.resolve(iterator.next());
     },
-    return(value?: unknown): Promise<IteratorResult<T>> {
-      return Promise.resolve(
+    async return(value?: unknown): Promise<IteratorResult<T>> {
+      return await Promise.resolve(
         iterator.return?.(value as T) ?? {
           done: true,
           value: value as T,
@@ -490,6 +498,34 @@ function toAsyncIterator<T>(
       );
     },
   };
+}
+
+function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      cleanup();
+      reject(signal.reason);
+    };
+    const cleanup = () => {
+      signal.removeEventListener("abort", abort);
+    };
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 function toReceiptError<TProviderId extends string>(

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -38,6 +38,7 @@ export class RetryTransport<TProviderId extends string = string>
    * @param transport The transport to wrap.
    * @param config Retry configuration.
    * @throws {RangeError} If retry configuration is invalid.
+   * @since 0.5.0
    */
   constructor(
     transport: Transport<TProviderId>,
@@ -55,6 +56,7 @@ export class RetryTransport<TProviderId extends string = string>
    * @param options Optional transport options.
    * @returns The final delivery receipt.
    * @throws {DOMException} If the operation is aborted.
+   * @since 0.5.0
    */
   async send(
     message: Message,
@@ -66,28 +68,9 @@ export class RetryTransport<TProviderId extends string = string>
     for (let attempt = 1; attempt <= this.config.maxAttempts; attempt++) {
       options?.signal?.throwIfAborted();
 
+      let receipt: Receipt<TProviderId>;
       try {
-        const receipt = await this.wrappedTransport.send(message, options);
-        if (receipt.successful) {
-          return this.withSuccessMetadata(receipt, attempt);
-        }
-
-        const failedReceipt = this.withFailureMetadata(receipt, attempt);
-        if (
-          attempt >= this.config.maxAttempts ||
-          !this.shouldRetryReceipt(failedReceipt)
-        ) {
-          return failedReceipt;
-        }
-
-        await this.waitBeforeRetry({
-          attempt,
-          nextAttempt: attempt + 1,
-          maxAttempts: this.config.maxAttempts,
-          delayMilliseconds: this.calculateDelay(attempt, failedReceipt),
-          receipt: failedReceipt,
-          reason: "retry",
-        }, options?.signal);
+        receipt = await this.wrappedTransport.send(message, options);
       } catch (error) {
         options?.signal?.throwIfAborted();
 
@@ -110,7 +93,29 @@ export class RetryTransport<TProviderId extends string = string>
           error,
           reason: "retry",
         }, options?.signal);
+        continue;
       }
+
+      if (receipt.successful) {
+        return this.withSuccessMetadata(receipt, attempt);
+      }
+
+      const failedReceipt = this.withFailureMetadata(receipt, attempt);
+      if (
+        attempt >= this.config.maxAttempts ||
+        !this.shouldRetryReceipt(failedReceipt)
+      ) {
+        return failedReceipt;
+      }
+
+      await this.waitBeforeRetry({
+        attempt,
+        nextAttempt: attempt + 1,
+        maxAttempts: this.config.maxAttempts,
+        delayMilliseconds: this.calculateDelay(attempt, failedReceipt),
+        receipt: failedReceipt,
+        reason: "retry",
+      }, options?.signal);
     }
 
     return this.createThrownFailure(lastThrownError, this.config.maxAttempts);
@@ -125,6 +130,7 @@ export class RetryTransport<TProviderId extends string = string>
    * @param options Optional transport options.
    * @returns An async iterable of receipts.
    * @throws {DOMException} If the operation is aborted.
+   * @since 0.5.0
    */
   async *sendMany(
     messages: Iterable<Message> | AsyncIterable<Message>,

--- a/packages/retry/src/retry-transport.ts
+++ b/packages/retry/src/retry-transport.ts
@@ -147,6 +147,7 @@ export class RetryTransport<TProviderId extends string = string>
     let launchPromise: Promise<void> | undefined;
     let launchError: unknown;
     let hasLaunchError = false;
+    let hasQueuedFailure = false;
     let pullingInput = false;
     let closed = false;
     const controller = new AbortController();
@@ -200,6 +201,7 @@ export class RetryTransport<TProviderId extends string = string>
         launchPromise != null ||
         inputDone ||
         hasLaunchError ||
+        hasQueuedFailure ||
         inFlight.size >= this.config.sendMany.maxConcurrent
       ) return;
 
@@ -247,6 +249,7 @@ export class RetryTransport<TProviderId extends string = string>
         if ("launched" in result) continue;
         inFlight.delete(result.index);
         completed.set(result.index, result);
+        if (!result.successful) hasQueuedFailure = true;
         startLaunch();
       }
       if (hasLaunchError) throw launchError;
@@ -280,16 +283,23 @@ export class RetryTransport<TProviderId extends string = string>
    * @since 0.5.0
    */
   async [Symbol.asyncDispose](): Promise<void> {
-    const asyncDisposable = this.wrappedTransport as Partial<AsyncDisposable>;
-    const asyncDispose = asyncDisposable[Symbol.asyncDispose];
-    if (typeof asyncDispose === "function") {
-      await asyncDispose.call(asyncDisposable);
-      return;
+    const wrappedTransport = Object(this.wrappedTransport) as {
+      readonly [key: symbol]: unknown;
+    };
+    const asyncDisposeSymbol = Symbol.asyncDispose;
+    if (typeof asyncDisposeSymbol === "symbol") {
+      const asyncDispose = wrappedTransport[asyncDisposeSymbol];
+      if (typeof asyncDispose === "function") {
+        await asyncDispose.call(wrappedTransport);
+        return;
+      }
     }
 
-    const disposable = this.wrappedTransport as Partial<Disposable>;
-    const dispose = disposable[Symbol.dispose];
-    if (typeof dispose === "function") dispose.call(disposable);
+    const disposeSymbol = Symbol.dispose;
+    if (typeof disposeSymbol === "symbol") {
+      const dispose = wrappedTransport[disposeSymbol];
+      if (typeof dispose === "function") dispose.call(wrappedTransport);
+    }
   }
 
   private withSuccessMetadata(
@@ -482,9 +492,13 @@ function getRetryAfterMilliseconds<TProviderId extends string>(
 function toAsyncIterator<T>(
   values: Iterable<T> | AsyncIterable<T>,
 ): AsyncIterator<T> {
-  if (Symbol.asyncIterator in values) return values[Symbol.asyncIterator]();
+  const asyncIterator =
+    (values as { readonly [Symbol.asyncIterator]?: unknown })[
+      Symbol.asyncIterator
+    ];
+  if (typeof asyncIterator === "function") return asyncIterator.call(values);
 
-  const iterator = values[Symbol.iterator]();
+  const iterator = (values as Iterable<T>)[Symbol.iterator]();
   return {
     async next(): Promise<IteratorResult<T>> {
       return await Promise.resolve(iterator.next());
@@ -504,12 +518,12 @@ function raceWithAbort<T>(
   promise: Promise<T>,
   signal: AbortSignal,
 ): Promise<T> {
-  if (signal.aborted) return Promise.reject(signal.reason);
+  if (signal.aborted) return Promise.reject(getAbortReason(signal));
 
   return new Promise((resolve, reject) => {
     const abort = () => {
       cleanup();
-      reject(signal.reason);
+      reject(getAbortReason(signal));
     };
     const cleanup = () => {
       signal.removeEventListener("abort", abort);
@@ -526,6 +540,11 @@ function raceWithAbort<T>(
       },
     );
   });
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason ??
+    new DOMException("The operation was aborted.", "AbortError");
 }
 
 function toReceiptError<TProviderId extends string>(

--- a/packages/retry/tsdown.config.ts
+++ b/packages/retry/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: "src/index.ts",
+  dts: true,
+  format: ["esm", "cjs"],
+  platform: "neutral",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,19 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
 
+  packages/retry:
+    dependencies:
+      '@upyo/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.12.9(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
   packages/sendgrid:
     dependencies:
       '@upyo/core':
@@ -1419,11 +1432,6 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1456,20 +1464,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-bytes@7.1.0:
@@ -2535,9 +2535,9 @@ snapshots:
     dependencies:
       format: 0.2.2
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   floating-vue@5.2.2(vue@3.5.39(typescript@5.8.3)):
     dependencies:
@@ -2965,8 +2965,6 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.15: {}
 
   ohash@2.0.11: {}
@@ -2991,19 +2989,11 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3184,8 +3174,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tokenx@1.3.0: {}
 
@@ -3313,9 +3303,9 @@ snapshots:
   vite@7.3.6(@types/node@24.0.13)(jiti@2.4.2):
     dependencies:
       esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
       rollup: 4.44.2
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@upyo/resend':
         specifier: 'workspace:'
         version: link:../packages/resend
+      '@upyo/retry':
+        specifier: 'workspace:'
+        version: link:../packages/retry
       '@upyo/sendgrid':
         specifier: 'workspace:'
         version: link:../packages/sendgrid


### PR DESCRIPTION
This pull request adds *@upyo/retry*, a transport decorator for transient delivery failures.

The retry behavior lives outside provider transports on purpose.  Upyo already has a shared `Transport` interface and structured failure metadata in *@upyo/core*, so retries can be expressed as composition instead of being copied into every provider package.  A user can wrap one provider when they want single-provider retry, wrap a pool when they want to retry the whole pooled operation, or place retry inside a pool when each provider should get its own attempt budget.

The implementation keeps the wrapped transport’s provider id and returns the same `Receipt` shape callers already handle.  Successful and failed receipts get attempt metadata, and failed receipts keep provider details when the wrapped transport supplies them.  Retry decisions use `retryable` and structured `errors` metadata by default, with a `shouldRetry` hook for provider-specific or application-specific policy.  Caller cancellation still rejects immediately, so an `AbortSignal` remains a hard stop rather than another retryable failure.

Backoff is configurable but deliberately small in surface area: total attempts, base delay, maximum delay, factor, jitter, a custom random source, and an overrideable wait function.  `Retry-After` metadata wins over computed backoff when a provider gives one.  The custom wait hook keeps tests deterministic and lets hosts plug retry timing into their own scheduler if they need to.

`sendMany()` sends each message through the same retry path while bounding parallelism.  It refills available slots when any in-flight send settles, but it still yields receipts in input order.  The iterator is closed on early exit, so async producers can run their cleanup paths when a consumer stops reading or a send fails.

Documentation was added alongside the package.  *docs/transports/retry.md* explains how retry classification, backoff, `Retry-After`, cancellation, and composition with pool transport work.  The package is also linked from the *README.md*, the VitePress navigation, the landing page transport list, and *CHANGES.md*.

Local checks run:

 -  `mise check`
 -  `mise run docs:build`

Full runtime tests were run during the implementation work.  After the final docs-only amendment, I did not rerun the full `mise test` suite.
