### PR TITLE
LogTape transport for delivery observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ functions.  It's structured as a monorepo with multiple packages:
  -  *@upyo/core*: Shared types and interfaces for email messages
  -  *@upyo/smtp*: SMTP transport implementation
  -  *@upyo/lettermint*: Lettermint transport implementation
+ -  *@upyo/logtape*: LogTape observability transport
  -  *@upyo/maileroo*: Maileroo transport implementation
  -  *@upyo/mailgun*: Mailgun transport implementation
  -  *@upyo/sendgrid*: SendGrid transport implementation
@@ -242,6 +243,8 @@ export interface Transport {
     inspection capabilities
  -  *OpenTelemetry transport*: Decorator pattern for adding observability to
     any transport
+ -  *LogTape transport*: Log-only or decorator transport for structured email
+    delivery logs
  -  *Configuration factories*: `createXConfig()` functions apply
     provider-specific defaults and validation
  -  *Provider-specific optimization*: Each transport optimizes for its protocol
@@ -281,6 +284,8 @@ the application.
 
  -  *@upyo/retry*: Decorator transport that retries transient failures with
     configurable backoff, jitter, and `sendMany()` throttling
+ -  *@upyo/logtape*: Log-only or decorator transport that records delivery
+    lifecycle events through LogTape
  -  *@upyo/mock*: Testing transport that captures sent messages for inspection
     without external dependencies
  -  *@upyo/opentelemetry*: Decorator transport that adds OpenTelemetry
@@ -296,6 +301,8 @@ the application.
     utilities
  -  *OpenTelemetry*: Transparent wrapper, metrics collection, distributed
     tracing, error classification
+ -  *LogTape*: Structured lifecycle logging with configurable categories and
+    levels
 
 ### Build system
 
@@ -317,6 +324,8 @@ the application.
     without external dependencies
  -  *Observability testing*: OpenTelemetry transport includes integration tests
     with real OpenTelemetry SDK
+ -  *Logging testing*: LogTape transport uses the LogTape recorder to verify
+    structured delivery events
  -  *Environment isolation*: *.env* files for test configuration with mise
     environment loading
 
@@ -819,7 +828,7 @@ Common tasks for agents
  -  *Bug fixes*: Ensure fixes work across all supported runtimes
  -  *Feature additions*: Maintain backward compatibility and update relevant
     documentation
- -  *Adding observability*: Use OpenTelemetry transport as decorator for any
-    transport
+ -  *Adding observability*: Use the OpenTelemetry or LogTape decorator around
+    any transport
  -  *Testing workflows*: Use mock transport for comprehensive testing without
     external dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ Version 0.6.0
 
 To be released.
 
+### @upyo/logtape
+
+ -  Added LogTape observability transport.
+
+     -  Added `LogTapeTransport` class for logging email delivery lifecycle
+        events with configurable categories and levels.
+     -  Supports log-only development use and decorating another transport
+        without changing its receipts or errors.
+     -  Supports optional full-message logging, streaming `sendMany()`,
+        `AbortSignal` cancellation, and wrapped transport disposal.
+
 ### @upyo/maileroo
 
  -  Added [Maileroo] transport.  [[#30], [#31]]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ sending messages.  The following is a list of the available packages:
 | [@upyo/smtp](/packages/smtp/)                   | [JSR][jsr:@upyo/smtp]          | [npm][npm:@upyo/smtp]          | SMTP transport                                     |
 | [@upyo/jmap](/packages/jmap/)                   | [JSR][jsr:@upyo/jmap]          | [npm][npm:@upyo/jmap]          | [JMAP] transport (RFC 8620/8621)                   |
 | [@upyo/lettermint](/packages/lettermint/)       | [JSR][jsr:@upyo/lettermint]    | [npm][npm:@upyo/lettermint]    | [Lettermint] transport                             |
+| [@upyo/logtape](/packages/logtape/)             | [JSR][jsr:@upyo/logtape]       | [npm][npm:@upyo/logtape]       | [LogTape] observability transport                  |
 | [@upyo/maileroo](/packages/maileroo/)           | [JSR][jsr:@upyo/maileroo]      | [npm][npm:@upyo/maileroo]      | [Maileroo] transport                               |
 | [@upyo/mailgun](/packages/mailgun/)             | [JSR][jsr:@upyo/mailgun]       | [npm][npm:@upyo/mailgun]       | [Mailgun] transport                                |
 | [@upyo/plunk](/packages/plunk/)                 | [JSR][jsr:@upyo/plunk]         | [npm][npm:@upyo/plunk]         | [Plunk] transport                                  |
@@ -90,6 +91,9 @@ sending messages.  The following is a list of the available packages:
 [jsr:@upyo/lettermint]: https://jsr.io/@upyo/lettermint
 [npm:@upyo/lettermint]: https://www.npmjs.com/package/@upyo/lettermint
 [Lettermint]: https://lettermint.co/
+[jsr:@upyo/logtape]: https://jsr.io/@upyo/logtape
+[npm:@upyo/logtape]: https://www.npmjs.com/package/@upyo/logtape
+[LogTape]: https://logtape.org/
 [jsr:@upyo/maileroo]: https://jsr.io/@upyo/maileroo
 [npm:@upyo/maileroo]: https://www.npmjs.com/package/@upyo/maileroo
 [Maileroo]: https://maileroo.com/

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,8 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@logtape/logtape@^2.2.4": "2.2.4",
+    "jsr:@logtape/testing@^2.2.4": "2.2.4",
     "jsr:@std/fs@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.9": "1.0.9",
     "jsr:@std/path@^1.1.1": "1.1.1",
@@ -15,6 +17,15 @@
     "npm:tsdown@~0.12.7": "0.12.9_rolldown@1.0.0-beta.24"
   },
   "jsr": {
+    "@logtape/logtape@2.2.4": {
+      "integrity": "8ee23b7c8d4b2e28c43a3a16027a7a27ed3d453c395c7d91b9960640399201ec"
+    },
+    "@logtape/testing@2.2.4": {
+      "integrity": "17c275d0389eca7b0601ce9fd5a25ed9b30c237b94858c1e9892b3ba357782d9",
+      "dependencies": [
+        "jsr:@logtape/logtape"
+      ]
+    },
     "@std/fs@1.0.19": {
       "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
       "dependencies": [
@@ -171,111 +182,65 @@
     },
     "@rolldown/binding-darwin-arm64@1.0.0-beta.24": {
       "integrity": "sha512-gE4HGjIioZaMGZupq2zQQdqhlRV2b2qnjFHHkJEW50zVDmiVNWwdHjwvZDPx9JfW5y4GuHgp/zKDLZZbJlQ1/Q==",
-      "os": [
-        "darwin"
-      ],
-      "cpu": [
-        "arm64"
-      ]
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@rolldown/binding-darwin-x64@1.0.0-beta.24": {
       "integrity": "sha512-h2HfOtqmjIHIz9WdpKAJ8sBfLNGkrMlwrCfNV2MDDGu0x3YdYBYPE+ozS5PvE53Tp8y6EYn2/thNWJTGWy/N3Q==",
-      "os": [
-        "darwin"
-      ],
-      "cpu": [
-        "x64"
-      ]
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@rolldown/binding-freebsd-x64@1.0.0-beta.24": {
       "integrity": "sha512-lx3Q2TU2bbY4yDCZ6e+Wiom3VMLFlZmQswx/1CyjFd+Vv3Q+99SZm6CSfNAIZBaWD246yQRRr1Vx+iIoWCdYzQ==",
-      "os": [
-        "freebsd"
-      ],
-      "cpu": [
-        "x64"
-      ]
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
     "@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.24": {
       "integrity": "sha512-PLtsV6uf3uS1/cNF8Wu/kitTpXT2YpOZbN6VJm7oMi5A8o5oO0vh8STCB71O5k2kwQMVycsmxHWFk2ZyEa6aMw==",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm"
-      ]
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@rolldown/binding-linux-arm64-gnu@1.0.0-beta.24": {
       "integrity": "sha512-UxGukDkWnv7uS5R+BPVeJ4FSuwA+lgC62LRsyPPSJhJhKMNGZ2W9sQPIpEtBRlww8t0qR6QBsiD5TGLW98ktGw==",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm64"
-      ]
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@rolldown/binding-linux-arm64-musl@1.0.0-beta.24": {
       "integrity": "sha512-vB99yGYW9FOQe4lk3MNKa13+vRj+7waZFlRE3Ba/IpEy7RFxZ78ASkPLXkz4+kYYbUvMnRaOfk9RKX2fqYZRUg==",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm64"
-      ]
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@rolldown/binding-linux-x64-gnu@1.0.0-beta.24": {
       "integrity": "sha512-fAMZBWutuKWHsyvHVsKjFYRXVgTbzBfNmomzPPpog8UtdkHk5Vnb0qVEeZP4hR4TsXnKfzD2EQ98NRqFej5QYA==",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ]
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@rolldown/binding-linux-x64-musl@1.0.0-beta.24": {
       "integrity": "sha512-0UY/Qo8fAlpolcWOg2ZU7SCUrsCJWifdRMliV9GXlZaBKbMoVNFw0pHGDm9cj/3TWhJu/iB0peZK00dm22LlNw==",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ]
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@rolldown/binding-wasm32-wasi@1.0.0-beta.24": {
       "integrity": "sha512-7ubbtKCo6FBuAM4q6LoT5dOea7f/zj9OYXgumbwSmA0fw18mN5h8SrFTUjl7h9MpPkOyhi2uY6ss4pb39KXkcw==",
       "dependencies": [
         "@napi-rs/wasm-runtime"
       ],
-      "cpu": [
-        "wasm32"
-      ]
+      "cpu": ["wasm32"]
     },
     "@rolldown/binding-win32-arm64-msvc@1.0.0-beta.24": {
       "integrity": "sha512-S5WKIabtRBJyzu31KnJRlbZRR6FMrTMzYRrNTnIY2hWWXfpcB1PNuHqbo+98ODLpH8knul4Vyf5sCL61okLTjA==",
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "arm64"
-      ]
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "@rolldown/binding-win32-ia32-msvc@1.0.0-beta.24": {
       "integrity": "sha512-5EW8mzHoukz3zBn/VAaTapK+i+/ZFbSSP9meDmLSuGnk6La8uLAPc7E+6S3gbJnQ6k8lSC6ipIIeXC4SPdttKQ==",
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "ia32"
-      ]
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@rolldown/binding-win32-x64-msvc@1.0.0-beta.24": {
       "integrity": "sha512-KpurHt8+B0yTg9gHroC3H/Tf2c9VfjIBsC/wVHTf7GGAe+xkw1+5iYB3Y5iSy3OaMTGq1U3/YEvTqqBdSbDMUg==",
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "x64"
-      ]
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@rolldown/pluginutils@1.0.0-beta.24": {
       "integrity": "sha512-NMiim/enJlffMP16IanVj1ajFNEg8SaMEYyxyYfJoEyt5EiFT3HUH/T2GRdeStNWp+/kg5U8DiJqnQBgLQ8uCw=="
@@ -470,6 +435,12 @@
       "npm:tsdown@~0.12.7"
     ],
     "members": {
+      "packages/logtape": {
+        "dependencies": [
+          "jsr:@logtape/logtape@^2.2.4",
+          "jsr:@logtape/testing@^2.2.4"
+        ]
+      },
       "packages/opentelemetry": {
         "dependencies": [
           "npm:@opentelemetry/api@^1.9.0",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,6 +14,7 @@ const packages: readonly string[] = [
   "core",
   "jmap",
   "lettermint",
+  "logtape",
   "maileroo",
   "mailgun",
   "plunk",
@@ -85,6 +86,7 @@ const NAV = [
       { text: "Amazon SES", link: "/transports/ses" },
       { text: "Pool transport", link: "/transports/pool" },
       { text: "Retry transport", link: "/transports/retry" },
+      { text: "LogTape", link: "/transports/logtape" },
       { text: "OpenTelemetry", link: "/transports/opentelemetry" },
       { text: "Mock transport", link: "/transports/mock" },
       { text: "Custom transport", link: "/transports/custom" },
@@ -104,6 +106,7 @@ const NAV = [
       { text: "@upyo/sendgrid", link: "https://jsr.io/@upyo/sendgrid/doc" },
       { text: "@upyo/ses", link: "https://jsr.io/@upyo/ses/doc" },
       { text: "@upyo/retry", link: "https://jsr.io/@upyo/retry/doc" },
+      { text: "@upyo/logtape", link: "https://jsr.io/@upyo/logtape/doc" },
       {
         text: "@upyo/opentelemetry",
         link: "https://jsr.io/@upyo/opentelemetry/doc",

--- a/docs/.vitepress/theme/components/landing/SectionDevExperience.vue
+++ b/docs/.vitepress/theme/components/landing/SectionDevExperience.vue
@@ -9,10 +9,15 @@ const sent = transport.getSentMessages();
 sent[0].subject;                // "Hello from Upyo!"
 sent[0].recipients[0].address;  // "rachel@example.net"`;
 
-const otelCode = `const transport = createOpenTelemetryTransport(base, {
+const observabilityCode = `const traced = createOpenTelemetryTransport(base, {
   serviceName: "email-service",
   metrics: { enabled: true },
   tracing: { enabled: true },
+});
+
+const transport = new LogTapeTransport({
+  transport: traced,
+  category: ["app", "email"],
 });
 
 // your sending code stays the same
@@ -23,13 +28,13 @@ await transport.send(message);`;
   <section class="lp-section lp-section--paper">
     <div class="lp-container">
       <div class="lp-head lp-reveal">
-        <p class="lp-eyebrow">Testing &amp; telemetry</p>
+        <p class="lp-eyebrow">Testing &amp; observability</p>
         <h2 class="lp-heading">Built to be developed against</h2>
         <p class="lp-lead">
-          Two small things make day-to-day work easier: a mock transport for
-          your tests, and OpenTelemetry for when you need to see what's
-          happening in production. Both implement the same interface as every
-          other transport, so they slot in without touching your sending code.
+          Mock email workflows without sending, record structured lifecycle
+          logs with LogTape, and trace production delivery with OpenTelemetry.
+          Each uses the same interface as every other transport, so they slot
+          in without touching your sending code.
         </p>
       </div>
 
@@ -48,16 +53,21 @@ await transport.send(message);`;
         </div>
 
         <div class="lp-duo__col">
-          <h3 class="lp-duo__title">See what's happening in production</h3>
+          <h3 class="lp-duo__title">Observe every delivery</h3>
           <p class="lp-duo__desc">
-            Wrap any transport to get traces and metrics like delivery rates,
-            latency, and error classification, with nothing to change in the
-            code that actually sends.
+            Use LogTape for structured delivery logs, or wrap the same
+            transport with OpenTelemetry for traces and metrics. Stack them
+            when you want both views without changing the code that sends.
           </p>
-          <CodeBlock file="observe.ts" :code="otelCode" />
-          <a class="lp-arrow" :href="withBase('/transports/opentelemetry')">
-            OpenTelemetry transport <span class="lp-arrow__i">→</span>
-          </a>
+          <CodeBlock file="observe.ts" :code="observabilityCode" />
+          <div class="lp-duo__links">
+            <a class="lp-arrow" :href="withBase('/transports/logtape')">
+              LogTape transport <span class="lp-arrow__i">→</span>
+            </a>
+            <a class="lp-arrow" :href="withBase('/transports/opentelemetry')">
+              OpenTelemetry transport <span class="lp-arrow__i">→</span>
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/.vitepress/theme/components/landing/SectionTransports.vue
+++ b/docs/.vitepress/theme/components/landing/SectionTransports.vue
@@ -32,6 +32,7 @@ const utilities = [
   { name: "Pool", desc: "Load-balance and fail over across transports.", link: "/transports/pool" },
   { name: "Retry", desc: "Backoff and jitter for transient failures.", link: "/transports/retry" },
   { name: "Mock", desc: "Capture messages in tests, send nothing.", link: "/transports/mock" },
+  { name: "LogTape", desc: "Structured lifecycle logs, with or without delivery.", link: "/transports/logtape" },
   { name: "OpenTelemetry", desc: "Traces and metrics for any transport.", link: "/transports/opentelemetry" },
   { name: "Custom", desc: "Build your own in a couple of methods.", link: "/transports/custom" },
 ];

--- a/docs/.vitepress/theme/components/landing/landing.css
+++ b/docs/.vitepress/theme/components/landing/landing.css
@@ -728,6 +728,17 @@
   margin-top: 1.3rem;
 }
 
+.lp-duo__links {
+  margin-top: 1.3rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.25rem;
+}
+
+.lp-duo__links .lp-arrow {
+  margin-top: 0;
+}
+
 /* ========================================================================== *
  * Sponsor / closing
  * ========================================================================== */

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ description: >-
   Upyo is a small, cross-runtime email library for JavaScript and TypeScript.
   Write a message once and send it on Node.js, Deno, Bun, and edge functions,
   through SMTP or providers like Lettermint, Maileroo, Mailgun, Resend,
-  SendGrid, and Amazon SES, with retry, failover, testing, and telemetry
-  transports sharing the same type-safe API.
+  SendGrid, and Amazon SES, with retry, failover, testing, structured logging,
+  and telemetry transports sharing the same type-safe API.
 ---
 
 <script setup>

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@logtape/logtape": "catalog:",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/resources": "catalog:",
     "@opentelemetry/sdk-metrics": "catalog:",
@@ -10,6 +11,7 @@
     "@upyo/core": "workspace:",
     "@upyo/jmap": "workspace:",
     "@upyo/lettermint": "workspace:",
+    "@upyo/logtape": "workspace:",
     "@upyo/maileroo": "workspace:",
     "@upyo/mailgun": "workspace:",
     "@upyo/mock": "workspace:",

--- a/docs/transports/logtape.md
+++ b/docs/transports/logtape.md
@@ -29,23 +29,23 @@ Install *@upyo/logtape* together with LogTape:
 
 ::: code-group
 
-~~~~ sh [npm]
+~~~~ bash [npm]
 npm add @upyo/logtape @logtape/logtape
 ~~~~
 
-~~~~ sh [pnpm]
+~~~~ bash [pnpm]
 pnpm add @upyo/logtape @logtape/logtape
 ~~~~
 
-~~~~ sh [Yarn]
+~~~~ bash [Yarn]
 yarn add @upyo/logtape @logtape/logtape
 ~~~~
 
-~~~~ sh [Deno]
+~~~~ bash [Deno]
 deno add jsr:@upyo/logtape jsr:@logtape/logtape
 ~~~~
 
-~~~~ sh [Bun]
+~~~~ bash [Bun]
 bun add @upyo/logtape @logtape/logtape
 ~~~~
 

--- a/docs/transports/logtape.md
+++ b/docs/transports/logtape.md
@@ -120,7 +120,8 @@ The decorator preserves the wrapped provider id, forwards `AbortSignal`, uses
 the wrapped `sendMany()` implementation, and passes successful and failed
 receipts through unchanged.  Exceptions are logged with the original error
 object and then rethrown.  Explicit disposal is also forwarded to disposable
-wrapped transports.
+wrapped transports.  If a caller stops reading a batch early, receipts are
+still logged for messages that the wrapped transport has already consumed.
 
 LogTape transport can be nested with retry, pool, and OpenTelemetry
 transports.  The outer decorator observes the complete operation performed by

--- a/docs/transports/logtape.md
+++ b/docs/transports/logtape.md
@@ -1,0 +1,183 @@
+---
+description: >-
+  Structured LogTape logging for Upyo email delivery, with log-only and
+  decorator modes, configurable categories and levels, and privacy controls.
+---
+
+LogTape transport
+=================
+
+*This transport is introduced in Upyo 0.6.0.*
+
+The LogTape transport records email delivery lifecycle events as structured
+[LogTape] logs.  It can be used by itself during local development, where no
+message is actually delivered, or as a decorator around another transport.
+In decorator mode, the wrapped transport still performs delivery and its
+receipts and errors pass through unchanged.
+
+Upyo does not configure LogTape on behalf of the application.  This follows
+LogTape's library-first design and leaves sinks, filters, and category levels
+under application control.
+
+[LogTape]: https://logtape.org/
+
+
+Installation
+------------
+
+Install *@upyo/logtape* together with LogTape:
+
+::: code-group
+
+~~~~ sh [npm]
+npm add @upyo/logtape @logtape/logtape
+~~~~
+
+~~~~ sh [pnpm]
+pnpm add @upyo/logtape @logtape/logtape
+~~~~
+
+~~~~ sh [Yarn]
+yarn add @upyo/logtape @logtape/logtape
+~~~~
+
+~~~~ sh [Deno]
+deno add jsr:@upyo/logtape jsr:@logtape/logtape
+~~~~
+
+~~~~ sh [Bun]
+bun add @upyo/logtape @logtape/logtape
+~~~~
+
+:::
+
+
+Log-only usage
+--------------
+
+With no wrapped transport, `LogTapeTransport` records the send and returns a
+synthetic successful receipt.  This is useful for exercising email workflows
+without sending real messages:
+
+~~~~ typescript twoslash
+import { configure, getConsoleSink } from "@logtape/logtape";
+import { createMessage } from "@upyo/core";
+import { LogTapeTransport } from "@upyo/logtape";
+
+await configure({
+  sinks: { console: getConsoleSink() },
+  loggers: [
+    { category: ["upyo"], lowestLevel: "debug", sinks: ["console"] },
+  ],
+});
+
+const transport = new LogTapeTransport();
+const message = createMessage({
+  from: "sender@example.com",
+  to: "recipient@example.net",
+  subject: "Welcome",
+  content: { text: "Welcome to our service." },
+});
+
+const receipt = await transport.send(message);
+if (receipt.successful) {
+  console.log(receipt.messageId); // "logtape-..."
+}
+~~~~
+
+The default category is `["upyo"]`.  A log-only receipt uses the provider id
+`"logtape"` and a generated message id, but it does not imply that an email
+was delivered outside the application.
+
+
+Decorating another transport
+----------------------------
+
+Pass another Upyo transport through the `transport` option to add logs around
+real delivery:
+
+~~~~ typescript twoslash
+import { LogTapeTransport } from "@upyo/logtape";
+import { SmtpTransport } from "@upyo/smtp";
+
+const smtp = new SmtpTransport({
+  host: "smtp.example.com",
+  port: 587,
+  secure: false,
+  auth: {
+    user: "smtp-user@example.com",
+    pass: "smtp-password",
+  },
+});
+
+const transport = new LogTapeTransport({
+  transport: smtp,
+  category: ["application", "email"],
+});
+~~~~
+
+The decorator preserves the wrapped provider id, forwards `AbortSignal`, uses
+the wrapped `sendMany()` implementation, and passes successful and failed
+receipts through unchanged.  Exceptions are logged with the original error
+object and then rethrown.  Explicit disposal is also forwarded to disposable
+wrapped transports.
+
+LogTape transport can be nested with retry, pool, and OpenTelemetry
+transports.  The outer decorator observes the complete operation performed by
+the inner transport, so choose the order according to which retries or
+failovers should appear as one logged operation.
+
+
+Categories and levels
+---------------------
+
+The lifecycle levels can be changed independently:
+
+~~~~ typescript twoslash
+import { LogTapeTransport } from "@upyo/logtape";
+
+const transport = new LogTapeTransport({
+  category: ["my-app", "outbound-email"],
+  levels: {
+    sending: "trace",
+    sent: "info",
+    failed: "fatal",
+  },
+});
+~~~~
+
+`sending`
+:   Level for `email.sending` events.  Defaults to `"debug"`.
+
+`sent`
+:   Level for `email.sent` events.  Defaults to `"info"`.
+
+`failed`
+:   Level for failed receipts and thrown errors.  Defaults to `"error"`.
+
+Every event includes the operation, transport id, recipient counts,
+attachment count, and priority.  Completion events additionally include
+duration and receipt or error details.
+
+
+Recording complete messages
+---------------------------
+
+Messages are excluded from structured log properties by default.  Set
+`recordMessage: true` to add the complete `Message` object to every lifecycle
+event:
+
+~~~~ typescript twoslash
+import { LogTapeTransport } from "@upyo/logtape";
+
+const transport = new LogTapeTransport({
+  recordMessage: true,
+});
+~~~~
+
+> [!CAUTION]
+> Complete messages can contain personal addresses, subjects, email bodies,
+> custom headers, and large attachment data.  Enable this option only for
+> sinks with suitable access controls and [redaction].
+
+[redaction]: https://logtape.org/manual/redaction

--- a/docs/transports/logtape.md
+++ b/docs/transports/logtape.md
@@ -120,8 +120,9 @@ The decorator preserves the wrapped provider id, forwards `AbortSignal`, uses
 the wrapped `sendMany()` implementation, and passes successful and failed
 receipts through unchanged.  Exceptions are logged with the original error
 object and then rethrown.  Explicit disposal is also forwarded to disposable
-wrapped transports.  If a caller stops reading a batch early, receipts are
-still logged for messages that the wrapped transport has already consumed.
+wrapped transports.  Completion logs are emitted as callers consume receipts.
+If a caller stops reading a batch early, the wrapped iterator is closed without
+being drained so the logging layer does not start additional delivery work.
 
 LogTape transport can be nested with retry, pool, and OpenTelemetry
 transports.  The outer decorator observes the complete operation performed by

--- a/packages/logtape/README.md
+++ b/packages/logtape/README.md
@@ -1,0 +1,58 @@
+<!-- deno-fmt-ignore-file -->
+
+@upyo/logtape
+=============
+
+*@upyo/logtape* records Upyo email delivery lifecycle events through
+[LogTape].  It can act as a log-only transport during local development or
+decorate another transport while preserving its delivery behavior.
+
+[LogTape]: https://logtape.org/
+
+
+Installation
+------------
+
+~~~~ bash
+deno add jsr:@upyo/logtape jsr:@logtape/logtape
+pnpm add @upyo/logtape @logtape/logtape
+~~~~
+
+
+Usage
+-----
+
+Configure LogTape in your application, then create a log-only transport:
+
+~~~~ typescript
+import { configure, getConsoleSink } from "@logtape/logtape";
+import { LogTapeTransport } from "@upyo/logtape";
+
+await configure({
+  sinks: { console: getConsoleSink() },
+  loggers: [
+    { category: ["upyo"], lowestLevel: "debug", sinks: ["console"] },
+  ],
+});
+
+const transport = new LogTapeTransport();
+const receipt = await transport.send(message);
+~~~~
+
+To deliver messages through another transport, pass it in the options object:
+
+~~~~ typescript
+const transport = new LogTapeTransport({
+  transport: smtpTransport,
+  category: ["application", "email"],
+  levels: {
+    sending: "debug",
+    sent: "info",
+    failed: "error",
+  },
+});
+~~~~
+
+Complete messages are excluded from structured logs by default.  Set
+`recordMessage: true` only when the configured sinks and redaction rules can
+safely handle addresses, bodies, headers, and attachment data.

--- a/packages/logtape/deno.json
+++ b/packages/logtape/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@upyo/logtape",
+  "version": "0.6.0",
+  "license": "MIT",
+  "exports": "./src/index.ts",
+  "imports": {
+    "@logtape/logtape": "jsr:@logtape/logtape@^2.2.4",
+    "@logtape/testing": "jsr:@logtape/testing@^2.2.4"
+  },
+  "exclude": [
+    "dist/"
+  ]
+}

--- a/packages/logtape/mise.toml
+++ b/packages/logtape/mise.toml
@@ -1,0 +1,45 @@
+[env]
+_.file = { path = ".env", redact = true }
+
+[tasks.build]
+description = "Build @upyo/logtape"
+run = "pnpm exec tsdown"
+sources = ["deno.json", "package.json", "tsdown.config.ts", "src/**/*.ts", "../../pnpm-lock.yaml", "../../pnpm-workspace.yaml"]
+outputs = ["dist/**/*"]
+
+[tasks."test:deno"]
+description = "Run @upyo/logtape tests with Deno"
+usage = '''
+flag "--coverage" help="Collect coverage data"
+flag "--junit-path <path>" help="Write JUnit XML test output"
+'''
+run = '''
+#!/usr/bin/env nu
+
+let args = ["test"]
+let args = if ($env.usage_coverage? | default "false" | into bool) {
+  $args | append "--coverage=../../coverage"
+} else {
+  $args
+}
+let args = if ($env.usage_junit_path? | default "" | is-not-empty) {
+  $args | append $"--junit-path=($env.usage_junit_path)"
+} else {
+  $args
+}
+deno ...$args
+'''
+
+[tasks."test:node"]
+description = "Run @upyo/logtape tests with Node.js"
+depends = ["build"]
+run = "node --experimental-transform-types --test"
+
+[tasks."test:bun"]
+description = "Run @upyo/logtape tests with Bun"
+depends = ["build"]
+run = "bun test --timeout=30000"
+
+[tasks.test]
+description = "Run @upyo/logtape tests across all runtimes"
+depends = ["test:deno", "test:node", "test:bun"]

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@upyo/logtape",
+  "version": "0.6.0",
+  "description": "LogTape observability transport for Upyo email library",
+  "keywords": [
+    "email",
+    "mail",
+    "logtape",
+    "logging",
+    "observability"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Hong Minhee",
+    "email": "hong@minhee.org",
+    "url": "https://hongminhee.org/"
+  },
+  "homepage": "https://upyo.org/transports/logtape",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dahlia/upyo.git",
+    "directory": "packages/logtape/"
+  },
+  "bugs": {
+    "url": "https://github.com/dahlia/upyo/issues"
+  },
+  "funding": [
+    "https://github.com/sponsors/dahlia"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "bun": ">=1.2.0",
+    "deno": ">=2.3.0"
+  },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "peerDependencies": {
+    "@logtape/logtape": "catalog:",
+    "@upyo/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@logtape/logtape": "catalog:",
+    "@logtape/testing": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "prepack": "mise run --no-deps :build",
+    "prepublish": "mise run --no-deps :build"
+  }
+}

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -1,0 +1,118 @@
+import type { LogLevel } from "@logtape/logtape";
+import type { Transport } from "@upyo/core";
+
+/**
+ * Log levels used for email delivery lifecycle events.
+ *
+ * @since 0.6.0
+ */
+export interface LogTapeTransportLevels {
+  /**
+   * Level used before an email is handed to the transport.
+   *
+   * @default "debug"
+   */
+  readonly sending?: LogLevel;
+
+  /**
+   * Level used after an email is sent successfully.
+   *
+   * @default "info"
+   */
+  readonly sent?: LogLevel;
+
+  /**
+   * Level used when a transport returns a failed receipt or throws.
+   *
+   * @default "error"
+   */
+  readonly failed?: LogLevel;
+}
+
+/**
+ * Options for {@link LogTapeTransport}.
+ *
+ * @typeParam TProviderId The provider id of the wrapped transport.
+ * @since 0.6.0
+ */
+export interface LogTapeTransportOptions<
+  TProviderId extends string = "logtape",
+> {
+  /**
+   * Transport that performs the actual delivery.
+   *
+   * When omitted, the LogTape transport only logs the delivery and returns a
+   * synthetic successful receipt.
+   */
+  readonly transport?: Transport<TProviderId>;
+
+  /**
+   * LogTape category used for delivery logs.
+   *
+   * @default ["upyo"]
+   */
+  readonly category?: string | readonly string[];
+
+  /**
+   * Whether to include the complete email message in structured log
+   * properties.
+   *
+   * Messages may contain sensitive or large values, including email bodies,
+   * headers, and attachment data.
+   *
+   * @default false
+   */
+  readonly recordMessage?: boolean;
+
+  /**
+   * Levels used for delivery lifecycle events.
+   */
+  readonly levels?: LogTapeTransportLevels;
+}
+
+/**
+ * Fully resolved options used by {@link LogTapeTransport}.
+ *
+ * @typeParam TProviderId The provider id of the wrapped transport.
+ * @since 0.6.0
+ */
+export interface ResolvedLogTapeTransportOptions<
+  TProviderId extends string = "logtape",
+> {
+  /** Transport that performs the actual delivery, if configured. */
+  readonly transport?: Transport<TProviderId>;
+
+  /** Resolved LogTape category. */
+  readonly category: readonly string[];
+
+  /** Whether complete messages are included in structured logs. */
+  readonly recordMessage: boolean;
+
+  /** Resolved delivery lifecycle log levels. */
+  readonly levels: Required<LogTapeTransportLevels>;
+}
+
+/**
+ * Resolves LogTape transport options with their defaults.
+ *
+ * @param options User-provided transport options.
+ * @returns Fully resolved transport options.
+ * @since 0.6.0
+ */
+export function resolveLogTapeTransportOptions<
+  TProviderId extends string,
+>(
+  options: LogTapeTransportOptions<TProviderId>,
+): ResolvedLogTapeTransportOptions<TProviderId> {
+  const category = options.category ?? ["upyo"];
+  return {
+    transport: options.transport,
+    category: typeof category === "string" ? [category] : [...category],
+    recordMessage: options.recordMessage ?? false,
+    levels: {
+      sending: options.levels?.sending ?? "debug",
+      sent: options.levels?.sent ?? "info",
+      failed: options.levels?.failed ?? "error",
+    },
+  };
+}

--- a/packages/logtape/src/index.ts
+++ b/packages/logtape/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * LogTape observability transport for Upyo.
+ *
+ * @module
+ */
+
+export { LogTapeTransport } from "./logtape-transport.ts";
+export type {
+  LogTapeTransportLevels,
+  LogTapeTransportOptions,
+  ResolvedLogTapeTransportOptions,
+} from "./config.ts";

--- a/packages/logtape/src/logtape-transport.test.ts
+++ b/packages/logtape/src/logtape-transport.test.ts
@@ -329,6 +329,7 @@ describe("LogTapeTransport", { concurrency: 1 }, () => {
       }
 
       assert.deepEqual(base.sentMessages, [message, secondMessage]);
+      assert.ok(base.closed);
     });
   });
 
@@ -585,6 +586,7 @@ class BufferedTransport implements Transport<"base"> {
 class PrefetchingTransport implements Transport<"base"> {
   readonly id = "base";
   readonly sentMessages: Message[] = [];
+  closed = false;
 
   send(): Promise<Receipt<"base">> {
     return Promise.reject(new TypeError("Use sendMany()."));
@@ -593,26 +595,30 @@ class PrefetchingTransport implements Transport<"base"> {
   async *sendMany(
     messages: Iterable<Message> | AsyncIterable<Message>,
   ): AsyncIterable<Receipt<"base">> {
-    const iterator = Symbol.asyncIterator in messages
-      ? messages[Symbol.asyncIterator]()
-      : messages[Symbol.iterator]();
-    const first = await iterator.next();
-    const second = await iterator.next();
-    if (first.done || second.done) return;
-    this.sentMessages.push(first.value, second.value);
+    try {
+      const iterator = Symbol.asyncIterator in messages
+        ? messages[Symbol.asyncIterator]()
+        : messages[Symbol.iterator]();
+      const first = await iterator.next();
+      const second = await iterator.next();
+      if (first.done || second.done) return;
+      this.sentMessages.push(first.value, second.value);
 
-    yield {
-      successful: true,
-      messageId: "base-prefetched-1",
-      provider: "base",
-    };
+      yield {
+        successful: true,
+        messageId: "base-prefetched-1",
+        provider: "base",
+      };
 
-    const third = await iterator.next();
-    if (!third.done) this.sentMessages.push(third.value);
-    yield {
-      successful: true,
-      messageId: "base-prefetched-2",
-      provider: "base",
-    };
+      const third = await iterator.next();
+      if (!third.done) this.sentMessages.push(third.value);
+      yield {
+        successful: true,
+        messageId: "base-prefetched-2",
+        provider: "base",
+      };
+    } finally {
+      this.closed = true;
+    }
   }
 }

--- a/packages/logtape/src/logtape-transport.test.ts
+++ b/packages/logtape/src/logtape-transport.test.ts
@@ -1,0 +1,475 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { configure, reset } from "@logtape/logtape";
+import { createLogRecorder, type LogRecorder } from "@logtape/testing";
+import {
+  createFailedReceipt,
+  createMessage,
+  type Message,
+  type Receipt,
+  type Transport,
+  type TransportOptions,
+} from "@upyo/core";
+import { LogTapeTransport } from "./logtape-transport.ts";
+
+const message = createMessage({
+  from: "sender@example.com",
+  to: ["first@example.net", "second@example.net"],
+  cc: "copy@example.net",
+  bcc: "blind-copy@example.net",
+  subject: "Test message",
+  content: { text: "Hello from Upyo." },
+  priority: "high",
+  attachments: [
+    {
+      inline: false,
+      filename: "hello.txt",
+      contentType: "text/plain",
+      content: new TextEncoder().encode("Hello."),
+      contentId: "hello@example.com",
+    },
+  ],
+});
+let recorderSequence: Promise<void> = Promise.resolve();
+
+const createProviderSpecificTransportWithoutWrapper = () => {
+  // @ts-expect-error A provider-specific type requires a wrapped transport.
+  return new LogTapeTransport<"base">();
+};
+void createProviderSpecificTransportWithoutWrapper;
+
+describe("LogTapeTransport", { concurrency: 1 }, () => {
+  it("logs standalone sends and returns a synthetic receipt", async () => {
+    await withRecorder(async (recorder) => {
+      const transport = new LogTapeTransport();
+      const typedTransport: Transport<"logtape"> = transport;
+
+      const receipt = await typedTransport.send(message);
+
+      assert.ok(receipt.successful);
+      assert.match(receipt.messageId, /^logtape-[0-9a-f-]+$/);
+      assert.equal(receipt.provider, "logtape");
+      assert.equal(receipt.attempts, 1);
+      assert.ok(receipt.timestamp != null);
+      assert.equal(transport.id, "logtape");
+      assert.equal(recorder.records.length, 2);
+      recorder.assertLogged({
+        category: ["upyo"],
+        level: "debug",
+        message: "Sending email.",
+        properties: {
+          event: "email.sending",
+          operation: "send",
+          transportId: "logtape",
+          recipientCount: 2,
+          ccRecipientCount: 1,
+          bccRecipientCount: 1,
+          attachmentCount: 1,
+          priority: "high",
+        },
+      });
+      recorder.assertLogged({
+        category: ["upyo"],
+        level: "info",
+        message: "Email sent.",
+        properties: {
+          event: "email.sent",
+          operation: "send",
+          transportId: "logtape",
+          messageId: receipt.messageId,
+          provider: "logtape",
+        },
+      });
+      assert.ok(
+        recorder.records.every((record) => !("message" in record.properties)),
+      );
+    });
+  });
+
+  it("supports custom categories, levels, and full message recording", async () => {
+    await withRecorder(async (recorder) => {
+      const transport = new LogTapeTransport({
+        category: ["application", "mail"],
+        recordMessage: true,
+        levels: {
+          sending: "trace",
+          sent: "warning",
+          failed: "fatal",
+        },
+      });
+
+      await transport.send(message);
+
+      recorder.assertLogged({
+        category: ["application", "mail"],
+        level: "trace",
+        properties: { event: "email.sending", message },
+      });
+      recorder.assertLogged({
+        category: ["application", "mail"],
+        level: "warning",
+        properties: { event: "email.sent", message },
+      });
+    });
+  });
+
+  it("decorates a transport without changing successful receipts", async () => {
+    await withRecorder(async (recorder) => {
+      const base = new RecordingTransport();
+      const transport = new LogTapeTransport({ transport: base });
+      const typedTransport: Transport<"base"> = transport;
+      const controller = new AbortController();
+
+      const receipt = await typedTransport.send(message, {
+        signal: controller.signal,
+      });
+
+      assert.deepEqual(receipt, {
+        successful: true,
+        messageId: "base-message-1",
+        provider: "base",
+      });
+      assert.equal(transport.id, "base");
+      assert.deepEqual(base.sentMessages, [message]);
+      assert.equal(base.lastOptions?.signal, controller.signal);
+      recorder.assertLogged({
+        level: "info",
+        properties: {
+          event: "email.sent",
+          transportId: "base",
+          messageId: "base-message-1",
+          provider: "base",
+        },
+      });
+    });
+  });
+
+  it("logs and preserves failed receipts", async () => {
+    await withRecorder(async (recorder) => {
+      const base = new RecordingTransport();
+      base.nextReceipt = createFailedReceipt("Provider rejected the message.", {
+        provider: "base",
+        category: "rejected",
+        code: "base.rejected",
+        retryable: false,
+      });
+      const transport = new LogTapeTransport({
+        transport: base,
+        levels: { failed: "fatal" },
+      });
+
+      const receipt = await transport.send(message);
+
+      assert.ok(!receipt.successful);
+      assert.deepEqual(receipt.errorMessages, [
+        "Provider rejected the message.",
+      ]);
+      recorder.assertLogged({
+        level: "fatal",
+        message: "Failed to send email.",
+        properties: {
+          event: "email.failed",
+          operation: "send",
+          transportId: "base",
+          errorMessages: receipt.errorMessages,
+          retryable: false,
+          provider: "base",
+        },
+      });
+    });
+  });
+
+  it("logs thrown errors and rethrows the original value", async () => {
+    await withRecorder(async (recorder) => {
+      const base = new RecordingTransport();
+      const error = new TypeError("Transport failed.");
+      base.throwError = error;
+      const transport = new LogTapeTransport({ transport: base });
+
+      let thrown: unknown;
+      try {
+        await transport.send(message);
+      } catch (caught) {
+        thrown = caught;
+      }
+
+      assert.equal(thrown, error);
+      recorder.assertLogged({
+        level: "error",
+        message: /Failed to send email/,
+        properties: {
+          event: "email.failed",
+          operation: "send",
+          transportId: "base",
+          error,
+        },
+      });
+    });
+  });
+
+  it("delegates sendMany while logging each message and receipt", async () => {
+    await withRecorder(async (recorder) => {
+      const base = new RecordingTransport();
+      const transport = new LogTapeTransport({ transport: base });
+      const secondMessage = createMessage({
+        from: "sender@example.com",
+        to: "third@example.net",
+        subject: "Second message",
+        content: { text: "Another message." },
+      });
+      async function* messages(): AsyncIterable<Message> {
+        yield message;
+        yield secondMessage;
+      }
+
+      const receipts: Receipt<"base">[] = [];
+      for await (const receipt of transport.sendMany(messages())) {
+        receipts.push(receipt);
+      }
+
+      assert.equal(base.sendManyCalls, 1);
+      assert.equal(base.sendCalls, 0);
+      assert.deepEqual(base.sentMessages, [message, secondMessage]);
+      assert.deepEqual(
+        receipts.map((receipt) => receipt.successful && receipt.messageId),
+        ["base-batch-1", "base-batch-2"],
+      );
+      assert.equal(
+        recorder.filter({ properties: { event: "email.sending" } }).length,
+        2,
+      );
+      assert.equal(
+        recorder.filter({ properties: { event: "email.sent" } }).length,
+        2,
+      );
+      assert.ok(
+        recorder.records.every(
+          (record) => record.properties.operation === "sendMany",
+        ),
+      );
+    });
+  });
+
+  it("logs every pending message when sendMany throws", async () => {
+    await withRecorder(async (recorder) => {
+      const secondMessage = createMessage({
+        from: "sender@example.com",
+        to: "third@example.net",
+        subject: "Second message",
+        content: { text: "Another message." },
+      });
+      const error = new TypeError("Batch transport failed.");
+      const base = new ConsumingThenThrowingTransport(error);
+      const transport = new LogTapeTransport({
+        transport: base,
+        recordMessage: true,
+      });
+
+      let thrown: unknown;
+      try {
+        for await (
+          const _receipt of transport.sendMany([
+            message,
+            secondMessage,
+          ])
+        ) {
+          // The wrapped transport throws before yielding a receipt.
+        }
+      } catch (caught) {
+        thrown = caught;
+      }
+
+      assert.equal(thrown, error);
+      assert.deepEqual(base.sentMessages, [message, secondMessage]);
+      const failures = recorder.filter({
+        properties: { event: "email.failed" },
+      });
+      assert.equal(failures.length, 2);
+      assert.deepEqual(
+        failures.map((record) => record.properties.message),
+        [message, secondMessage],
+      );
+      assert.deepEqual(
+        failures.map((record) => record.properties.recipientCount),
+        [2, 1],
+      );
+      assert.ok(
+        failures.every((record) => record.properties.error === error),
+      );
+    });
+  });
+
+  it("handles synchronous sendMany input in log-only mode", async () => {
+    await withRecorder(async (recorder) => {
+      const transport = new LogTapeTransport();
+      const secondMessage = createMessage({
+        from: "sender@example.com",
+        to: "third@example.net",
+        subject: "Second message",
+        content: { text: "Another message." },
+      });
+
+      const receipts: Receipt<"logtape">[] = [];
+      for await (
+        const receipt of transport.sendMany([message, secondMessage])
+      ) {
+        receipts.push(receipt);
+      }
+
+      assert.equal(receipts.length, 2);
+      assert.ok(receipts.every((receipt) => receipt.successful));
+      assert.notEqual(
+        receipts[0].successful && receipts[0].messageId,
+        receipts[1].successful && receipts[1].messageId,
+      );
+      assert.equal(
+        recorder.filter({ properties: { operation: "sendMany" } }).length,
+        4,
+      );
+    });
+  });
+
+  it("rejects an already aborted standalone send without logging", async () => {
+    await withRecorder(async (recorder) => {
+      const controller = new AbortController();
+      controller.abort();
+      const transport = new LogTapeTransport();
+
+      await assert.rejects(
+        () => transport.send(message, { signal: controller.signal }),
+        { name: "AbortError" },
+      );
+      assert.equal(recorder.records.length, 0);
+    });
+  });
+
+  it("disposes an asynchronous wrapped transport", async () => {
+    const base = new AsyncDisposableTransport();
+    const transport = new LogTapeTransport({ transport: base });
+
+    await transport[Symbol.asyncDispose]();
+
+    assert.ok(base.disposed);
+  });
+
+  it("falls back to disposing a synchronous wrapped transport", async () => {
+    const base = new DisposableTransport();
+    const transport = new LogTapeTransport({ transport: base });
+
+    await transport[Symbol.asyncDispose]();
+
+    assert.ok(base.disposed);
+  });
+});
+
+async function withRecorder(
+  run: (recorder: LogRecorder) => Promise<void>,
+): Promise<void> {
+  const execution = recorderSequence.then(() => runWithRecorder(run));
+  recorderSequence = execution.catch(() => undefined);
+  return await execution;
+}
+
+async function runWithRecorder(
+  run: (recorder: LogRecorder) => Promise<void>,
+): Promise<void> {
+  const recorder = createLogRecorder();
+  try {
+    await configure({
+      sinks: { recorder: recorder.sink },
+      loggers: [
+        { category: [], lowestLevel: "trace", sinks: ["recorder"] },
+        {
+          category: ["logtape", "meta"],
+          sinks: [],
+          parentSinks: "override",
+        },
+      ],
+    });
+    await run(recorder);
+  } finally {
+    await reset();
+  }
+}
+
+class RecordingTransport implements Transport<"base"> {
+  readonly id = "base";
+  readonly sentMessages: Message[] = [];
+  sendCalls = 0;
+  sendManyCalls = 0;
+  lastOptions?: TransportOptions;
+  nextReceipt: Receipt<"base"> = {
+    successful: true,
+    messageId: "base-message-1",
+    provider: "base",
+  };
+  throwError?: unknown;
+
+  send(
+    message: Message,
+    options?: TransportOptions,
+  ): Promise<Receipt<"base">> {
+    this.sendCalls++;
+    this.sentMessages.push(message);
+    this.lastOptions = options;
+    if (this.throwError != null) return Promise.reject(this.throwError);
+    return Promise.resolve(this.nextReceipt);
+  }
+
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt<"base">> {
+    this.sendManyCalls++;
+    this.lastOptions = options;
+    let index = 0;
+    for await (const message of messages) {
+      this.sentMessages.push(message);
+      if (this.throwError != null) throw this.throwError;
+      yield {
+        successful: true,
+        messageId: `base-batch-${++index}`,
+        provider: "base",
+      };
+    }
+  }
+}
+
+class AsyncDisposableTransport extends RecordingTransport
+  implements AsyncDisposable {
+  disposed = false;
+
+  [Symbol.asyncDispose](): Promise<void> {
+    this.disposed = true;
+    return Promise.resolve();
+  }
+}
+
+class DisposableTransport extends RecordingTransport implements Disposable {
+  disposed = false;
+
+  [Symbol.dispose](): void {
+    this.disposed = true;
+  }
+}
+
+class ConsumingThenThrowingTransport implements Transport<"base"> {
+  readonly id = "base";
+  readonly sentMessages: Message[] = [];
+
+  constructor(readonly error: unknown) {}
+
+  send(): Promise<Receipt<"base">> {
+    return Promise.reject(this.error);
+  }
+
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+  ): AsyncIterable<Receipt<"base">> {
+    for await (const message of messages) {
+      this.sentMessages.push(message);
+    }
+    yield* [] as Receipt<"base">[];
+    throw this.error;
+  }
+}

--- a/packages/logtape/src/logtape-transport.test.ts
+++ b/packages/logtape/src/logtape-transport.test.ts
@@ -250,6 +250,57 @@ describe("LogTapeTransport", { concurrency: 1 }, () => {
     });
   });
 
+  it("logs buffered receipts when the sendMany consumer stops early", async () => {
+    await withRecorder(async (recorder) => {
+      const secondMessage = createMessage({
+        from: "sender@example.com",
+        to: "third@example.net",
+        subject: "Second message",
+        content: { text: "Another message." },
+      });
+      const base = new BufferedTransport();
+      const transport = new LogTapeTransport({ transport: base });
+
+      for await (
+        const _receipt of transport.sendMany([message, secondMessage])
+      ) {
+        break;
+      }
+
+      assert.deepEqual(base.sentMessages, [message, secondMessage]);
+      assert.equal(base.yieldedReceiptCount, 2);
+      assert.equal(
+        recorder.filter({ properties: { event: "email.sent" } }).length,
+        2,
+      );
+    });
+  });
+
+  it("does not send more messages when a sequential consumer stops early", async () => {
+    await withRecorder(async (recorder) => {
+      const secondMessage = createMessage({
+        from: "sender@example.com",
+        to: "third@example.net",
+        subject: "Second message",
+        content: { text: "Another message." },
+      });
+      const base = new RecordingTransport();
+      const transport = new LogTapeTransport({ transport: base });
+
+      for await (
+        const _receipt of transport.sendMany([message, secondMessage])
+      ) {
+        break;
+      }
+
+      assert.deepEqual(base.sentMessages, [message]);
+      assert.equal(
+        recorder.filter({ properties: { event: "email.sent" } }).length,
+        1,
+      );
+    });
+  });
+
   it("logs every pending message when sendMany throws", async () => {
     await withRecorder(async (recorder) => {
       const secondMessage = createMessage({
@@ -471,5 +522,31 @@ class ConsumingThenThrowingTransport implements Transport<"base"> {
     }
     yield* [] as Receipt<"base">[];
     throw this.error;
+  }
+}
+
+class BufferedTransport implements Transport<"base"> {
+  readonly id = "base";
+  readonly sentMessages: Message[] = [];
+  yieldedReceiptCount = 0;
+
+  send(): Promise<Receipt<"base">> {
+    return Promise.reject(new TypeError("Use sendMany()."));
+  }
+
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+  ): AsyncIterable<Receipt<"base">> {
+    for await (const message of messages) {
+      this.sentMessages.push(message);
+    }
+    for (let index = 0; index < this.sentMessages.length; index++) {
+      this.yieldedReceiptCount++;
+      yield {
+        successful: true,
+        messageId: `base-buffered-${index + 1}`,
+        provider: "base",
+      };
+    }
   }
 }

--- a/packages/logtape/src/logtape-transport.test.ts
+++ b/packages/logtape/src/logtape-transport.test.ts
@@ -250,7 +250,7 @@ describe("LogTapeTransport", { concurrency: 1 }, () => {
     });
   });
 
-  it("logs buffered receipts when the sendMany consumer stops early", async () => {
+  it("closes buffered receipts when the sendMany consumer stops early", async () => {
     await withRecorder(async (recorder) => {
       const secondMessage = createMessage({
         from: "sender@example.com",
@@ -268,10 +268,10 @@ describe("LogTapeTransport", { concurrency: 1 }, () => {
       }
 
       assert.deepEqual(base.sentMessages, [message, secondMessage]);
-      assert.equal(base.yieldedReceiptCount, 2);
+      assert.equal(base.yieldedReceiptCount, 1);
       assert.equal(
         recorder.filter({ properties: { event: "email.sent" } }).length,
-        2,
+        1,
       );
     });
   });
@@ -298,6 +298,37 @@ describe("LogTapeTransport", { concurrency: 1 }, () => {
         recorder.filter({ properties: { event: "email.sent" } }).length,
         1,
       );
+    });
+  });
+
+  it("does not advance a prefetched batch after its consumer stops", async () => {
+    await withRecorder(async () => {
+      const secondMessage = createMessage({
+        from: "sender@example.com",
+        to: "third@example.net",
+        subject: "Second message",
+        content: { text: "Another message." },
+      });
+      const thirdMessage = createMessage({
+        from: "sender@example.com",
+        to: "fourth@example.net",
+        subject: "Third message",
+        content: { text: "One more message." },
+      });
+      const base = new PrefetchingTransport();
+      const transport = new LogTapeTransport({ transport: base });
+
+      for await (
+        const _receipt of transport.sendMany([
+          message,
+          secondMessage,
+          thirdMessage,
+        ])
+      ) {
+        break;
+      }
+
+      assert.deepEqual(base.sentMessages, [message, secondMessage]);
     });
   });
 
@@ -548,5 +579,40 @@ class BufferedTransport implements Transport<"base"> {
         provider: "base",
       };
     }
+  }
+}
+
+class PrefetchingTransport implements Transport<"base"> {
+  readonly id = "base";
+  readonly sentMessages: Message[] = [];
+
+  send(): Promise<Receipt<"base">> {
+    return Promise.reject(new TypeError("Use sendMany()."));
+  }
+
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+  ): AsyncIterable<Receipt<"base">> {
+    const iterator = Symbol.asyncIterator in messages
+      ? messages[Symbol.asyncIterator]()
+      : messages[Symbol.iterator]();
+    const first = await iterator.next();
+    const second = await iterator.next();
+    if (first.done || second.done) return;
+    this.sentMessages.push(first.value, second.value);
+
+    yield {
+      successful: true,
+      messageId: "base-prefetched-1",
+      provider: "base",
+    };
+
+    const third = await iterator.next();
+    if (!third.done) this.sentMessages.push(third.value);
+    yield {
+      successful: true,
+      messageId: "base-prefetched-2",
+      provider: "base",
+    };
   }
 }

--- a/packages/logtape/src/logtape-transport.ts
+++ b/packages/logtape/src/logtape-transport.ts
@@ -327,26 +327,7 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
     message: string,
     properties: Readonly<Record<string, unknown>>,
   ): void {
-    switch (level) {
-      case "trace":
-        this.logger.trace(message, properties);
-        break;
-      case "debug":
-        this.logger.debug(message, properties);
-        break;
-      case "info":
-        this.logger.info(message, properties);
-        break;
-      case "warning":
-        this.logger.warning(message, properties);
-        break;
-      case "error":
-        this.logger.error(message, properties);
-        break;
-      case "fatal":
-        this.logger.fatal(message, properties);
-        break;
-    }
+    this.logger[level](message, properties);
   }
 }
 

--- a/packages/logtape/src/logtape-transport.ts
+++ b/packages/logtape/src/logtape-transport.ts
@@ -82,6 +82,8 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
    *
    * A wrapped transport's `sendMany()` implementation is used directly so
    * provider-specific batching and streaming behavior are preserved.
+   * When iteration stops early, receipts are still drained and logged for
+   * messages that the wrapped transport has already consumed.
    *
    * @param messages Email messages to send.
    * @param options Optional transport options, including cancellation.
@@ -112,45 +114,46 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
       options,
       () => consumedCount++,
     );
+    const receipts = this.wrappedTransport.sendMany(
+      observedMessages,
+      options,
+    )[Symbol.asyncIterator]();
+    let iteratorDone = false;
+    let iteratorFailed = false;
 
     try {
-      for await (
-        const receipt of this.wrappedTransport.sendMany(
-          observedMessages,
-          options,
-        )
-      ) {
+      while (true) {
+        const result = await receipts.next();
+        if (result.done) {
+          iteratorDone = true;
+          break;
+        }
+
         const current = pending.dequeue();
         completedCount++;
-        this.logReceipt(receipt, current, "sendMany");
-        yield receipt;
+        this.logReceipt(result.value, current, "sendMany");
+        yield result.value;
       }
     } catch (error) {
-      const batchProperties = {
+      iteratorFailed = true;
+      this.logBatchThrownError(
+        error,
+        pending,
+        batchStartedAt,
         consumedCount,
         completedCount,
-        pendingCount: pending.size,
-      };
-      if (pending.size < 1) {
-        this.logThrownError(
-          error,
-          undefined,
-          "sendMany",
-          batchStartedAt,
-          batchProperties,
-        );
-      } else {
-        for (const pendingMessage of pending) {
-          this.logThrownError(
-            error,
-            pendingMessage.message,
-            "sendMany",
-            pendingMessage.startedAt,
-            batchProperties,
-          );
-        }
-      }
+      );
       throw error;
+    } finally {
+      if (!iteratorDone && !iteratorFailed) {
+        await this.drainPendingReceipts(
+          receipts,
+          pending,
+          batchStartedAt,
+          consumedCount,
+          completedCount,
+        );
+      }
     }
   }
 
@@ -289,6 +292,78 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
         error,
       },
     );
+  }
+
+  private logBatchThrownError(
+    error: unknown,
+    pending: PendingQueue<PendingMessage>,
+    batchStartedAt: number,
+    consumedCount: number,
+    completedCount: number,
+  ): void {
+    const batchProperties = {
+      consumedCount,
+      completedCount,
+      pendingCount: pending.size,
+    };
+    if (pending.size < 1) {
+      this.logThrownError(
+        error,
+        undefined,
+        "sendMany",
+        batchStartedAt,
+        batchProperties,
+      );
+      return;
+    }
+
+    for (const pendingMessage of pending) {
+      this.logThrownError(
+        error,
+        pendingMessage.message,
+        "sendMany",
+        pendingMessage.startedAt,
+        batchProperties,
+      );
+    }
+  }
+
+  private async drainPendingReceipts(
+    receipts: AsyncIterator<Receipt<TProviderId>>,
+    pending: PendingQueue<PendingMessage>,
+    batchStartedAt: number,
+    consumedCount: number,
+    completedCount: number,
+  ): Promise<void> {
+    // Snapshot the backlog so closing this wrapper does not deliberately
+    // extend delivery beyond work that the wrapped transport started.
+    const receiptsToDrain = pending.size;
+    let drainedCount = 0;
+    let iteratorDone = false;
+    try {
+      for (let index = 0; index < receiptsToDrain; index++) {
+        const result = await receipts.next();
+        if (result.done) {
+          iteratorDone = true;
+          break;
+        }
+
+        const current = pending.dequeue();
+        drainedCount++;
+        this.logReceipt(result.value, current, "sendMany");
+      }
+    } catch (error) {
+      this.logBatchThrownError(
+        error,
+        pending,
+        batchStartedAt,
+        consumedCount,
+        completedCount + drainedCount,
+      );
+      throw error;
+    }
+
+    if (!iteratorDone) await receipts.return?.();
   }
 
   private getMessageProperties(message: Message): Record<string, unknown> {

--- a/packages/logtape/src/logtape-transport.ts
+++ b/packages/logtape/src/logtape-transport.ts
@@ -216,15 +216,15 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
 
   private logReceipt(
     receipt: Receipt<TProviderId>,
-    pending: PendingMessage | undefined,
+    pendingMessage: PendingMessage | undefined,
     operation: SendOperation,
   ): void {
-    const durationMilliseconds = pending == null
+    const durationMilliseconds = pendingMessage == null
       ? undefined
-      : performance.now() - pending.startedAt;
-    const messageProperties = pending == null
+      : performance.now() - pendingMessage.startedAt;
+    const messageProperties = pendingMessage == null
       ? {}
-      : this.getMessageProperties(pending.message);
+      : this.getMessageProperties(pendingMessage.message);
 
     if (receipt.successful) {
       this.log(this.config.levels.sent, "Email sent.", {

--- a/packages/logtape/src/logtape-transport.ts
+++ b/packages/logtape/src/logtape-transport.ts
@@ -1,0 +1,341 @@
+import { getLogger, type Logger, type LogLevel } from "@logtape/logtape";
+import type { Message, Receipt, Transport, TransportOptions } from "@upyo/core";
+import {
+  type LogTapeTransportOptions,
+  type ResolvedLogTapeTransportOptions,
+  resolveLogTapeTransportOptions,
+} from "./config.ts";
+import { PendingQueue } from "./pending-queue.ts";
+
+type SendOperation = "send" | "sendMany";
+
+interface PendingMessage {
+  readonly message: Message;
+  readonly startedAt: number;
+}
+
+type LogTapeTransportConstructorArguments<TProviderId extends string> =
+  [TProviderId] extends ["logtape"] ? [
+      options?: LogTapeTransportOptions<TProviderId>,
+    ]
+    : [
+      options: LogTapeTransportOptions<TProviderId> & {
+        readonly transport: Transport<TProviderId>;
+      },
+    ];
+
+/**
+ * Transport that records email delivery lifecycle events through LogTape.
+ *
+ * With no wrapped transport, this class acts as a log-only transport and
+ * returns synthetic successful receipts.  When a transport is supplied, it
+ * decorates that transport without changing its receipts or thrown errors.
+ *
+ * @typeParam TProviderId The provider id of the wrapped transport, or
+ *                        `"logtape"` in log-only mode.
+ * @since 0.6.0
+ */
+export class LogTapeTransport<TProviderId extends string = "logtape">
+  implements Transport<TProviderId>, AsyncDisposable {
+  /** Provider id used by receipts from this transport. */
+  readonly id: TProviderId;
+
+  /** Fully resolved transport options. */
+  readonly config: ResolvedLogTapeTransportOptions<TProviderId>;
+
+  private readonly logger: Logger;
+  private readonly wrappedTransport?: Transport<TProviderId>;
+
+  /**
+   * Creates a LogTape transport.
+   *
+   * @param options Logging and optional wrapped transport configuration.
+   */
+  constructor(
+    ...[options]: LogTapeTransportConstructorArguments<TProviderId>
+  ) {
+    this.config = resolveLogTapeTransportOptions(options ?? {});
+    this.wrappedTransport = this.config.transport;
+    this.id = (this.wrappedTransport?.id ?? "logtape") as TProviderId;
+    this.logger = getLogger(this.config.category);
+  }
+
+  /**
+   * Sends one email while recording its delivery lifecycle.
+   *
+   * @param message The email message to send.
+   * @param options Optional transport options, including cancellation.
+   * @returns The wrapped transport receipt, or a synthetic successful receipt
+   *          in log-only mode.
+   * @throws {DOMException} If the operation is aborted.
+   * @throws {Error} If the wrapped transport throws an error.
+   */
+  send(
+    message: Message,
+    options?: TransportOptions,
+  ): Promise<Receipt<TProviderId>> {
+    return this.sendOne(message, options, "send");
+  }
+
+  /**
+   * Sends multiple emails while recording each delivery lifecycle.
+   *
+   * A wrapped transport's `sendMany()` implementation is used directly so
+   * provider-specific batching and streaming behavior are preserved.
+   *
+   * @param messages Email messages to send.
+   * @param options Optional transport options, including cancellation.
+   * @returns An async iterable of unmodified delivery receipts.
+   * @throws {DOMException} If the operation is aborted.
+   * @throws {Error} If the wrapped transport throws an error.
+   */
+  async *sendMany(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    options?: TransportOptions,
+  ): AsyncIterable<Receipt<TProviderId>> {
+    options?.signal?.throwIfAborted();
+
+    if (this.wrappedTransport == null) {
+      for await (const message of messages) {
+        yield await this.sendOne(message, options, "sendMany");
+      }
+      return;
+    }
+
+    const pending = new PendingQueue<PendingMessage>();
+    const batchStartedAt = performance.now();
+    let consumedCount = 0;
+    let completedCount = 0;
+    const observedMessages = this.observeMessages(
+      messages,
+      pending,
+      options,
+      () => consumedCount++,
+    );
+
+    try {
+      for await (
+        const receipt of this.wrappedTransport.sendMany(
+          observedMessages,
+          options,
+        )
+      ) {
+        const current = pending.dequeue();
+        completedCount++;
+        this.logReceipt(receipt, current, "sendMany");
+        yield receipt;
+      }
+    } catch (error) {
+      const batchProperties = {
+        consumedCount,
+        completedCount,
+        pendingCount: pending.size,
+      };
+      if (pending.size < 1) {
+        this.logThrownError(
+          error,
+          undefined,
+          "sendMany",
+          batchStartedAt,
+          batchProperties,
+        );
+      } else {
+        for (const pendingMessage of pending) {
+          this.logThrownError(
+            error,
+            pendingMessage.message,
+            "sendMany",
+            pendingMessage.startedAt,
+            batchProperties,
+          );
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Disposes the wrapped transport when it supports explicit resource
+   * management.
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    const transport = this.wrappedTransport;
+    if (transport == null) return;
+
+    if (isAsyncDisposable(transport)) {
+      await transport[Symbol.asyncDispose]();
+      return;
+    }
+
+    if (isDisposable(transport)) {
+      transport[Symbol.dispose]();
+    }
+  }
+
+  private async sendOne(
+    message: Message,
+    options: TransportOptions | undefined,
+    operation: SendOperation,
+  ): Promise<Receipt<TProviderId>> {
+    options?.signal?.throwIfAborted();
+    const startedAt = performance.now();
+    this.logSending(message, operation);
+
+    try {
+      const receipt = this.wrappedTransport == null
+        ? this.createSyntheticReceipt()
+        : await this.wrappedTransport.send(message, options);
+      this.logReceipt(receipt, { message, startedAt }, operation);
+      return receipt;
+    } catch (error) {
+      this.logThrownError(error, message, operation, startedAt);
+      throw error;
+    }
+  }
+
+  private async *observeMessages(
+    messages: Iterable<Message> | AsyncIterable<Message>,
+    pending: PendingQueue<PendingMessage>,
+    options: TransportOptions | undefined,
+    onConsume: () => void,
+  ): AsyncIterable<Message> {
+    for await (const message of messages) {
+      options?.signal?.throwIfAborted();
+      const startedAt = performance.now();
+      this.logSending(message, "sendMany");
+      pending.enqueue({ message, startedAt });
+      onConsume();
+      yield message;
+    }
+  }
+
+  private createSyntheticReceipt(): Receipt<TProviderId> {
+    return {
+      successful: true,
+      messageId: `logtape-${crypto.randomUUID()}`,
+      provider: this.id,
+      attempts: 1,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  private logSending(message: Message, operation: SendOperation): void {
+    this.log(this.config.levels.sending, "Sending email.", {
+      ...this.getMessageProperties(message),
+      event: "email.sending",
+      operation,
+      transportId: this.id,
+    });
+  }
+
+  private logReceipt(
+    receipt: Receipt<TProviderId>,
+    pending: PendingMessage | undefined,
+    operation: SendOperation,
+  ): void {
+    const durationMilliseconds = pending == null
+      ? undefined
+      : performance.now() - pending.startedAt;
+    const messageProperties = pending == null
+      ? {}
+      : this.getMessageProperties(pending.message);
+
+    if (receipt.successful) {
+      this.log(this.config.levels.sent, "Email sent.", {
+        ...messageProperties,
+        event: "email.sent",
+        operation,
+        transportId: this.id,
+        durationMilliseconds,
+        messageId: receipt.messageId,
+        provider: receipt.provider ?? this.id,
+        receipt,
+      });
+      return;
+    }
+
+    this.log(this.config.levels.failed, "Failed to send email.", {
+      ...messageProperties,
+      event: "email.failed",
+      operation,
+      transportId: this.id,
+      durationMilliseconds,
+      errorMessages: receipt.errorMessages,
+      errors: receipt.errors,
+      retryable: receipt.retryable,
+      provider: receipt.provider ?? this.id,
+      attempts: receipt.attempts,
+      receipt,
+    });
+  }
+
+  private logThrownError(
+    error: unknown,
+    message: Message | undefined,
+    operation: SendOperation,
+    startedAt: number,
+    extraProperties: Readonly<Record<string, unknown>> = {},
+  ): void {
+    this.log(
+      this.config.levels.failed,
+      "Failed to send email: {error}",
+      {
+        ...(message == null ? {} : this.getMessageProperties(message)),
+        ...extraProperties,
+        event: "email.failed",
+        operation,
+        transportId: this.id,
+        durationMilliseconds: performance.now() - startedAt,
+        error,
+      },
+    );
+  }
+
+  private getMessageProperties(message: Message): Record<string, unknown> {
+    return {
+      recipientCount: message.recipients.length,
+      ccRecipientCount: message.ccRecipients.length,
+      bccRecipientCount: message.bccRecipients.length,
+      attachmentCount: message.attachments.length,
+      priority: message.priority,
+      ...(this.config.recordMessage ? { message } : {}),
+    };
+  }
+
+  private log(
+    level: LogLevel,
+    message: string,
+    properties: Readonly<Record<string, unknown>>,
+  ): void {
+    switch (level) {
+      case "trace":
+        this.logger.trace(message, properties);
+        break;
+      case "debug":
+        this.logger.debug(message, properties);
+        break;
+      case "info":
+        this.logger.info(message, properties);
+        break;
+      case "warning":
+        this.logger.warning(message, properties);
+        break;
+      case "error":
+        this.logger.error(message, properties);
+        break;
+      case "fatal":
+        this.logger.fatal(message, properties);
+        break;
+    }
+  }
+}
+
+function isAsyncDisposable(value: object): value is object & AsyncDisposable {
+  return Symbol.asyncDispose in value &&
+    typeof value[Symbol.asyncDispose] === "function";
+}
+
+function isDisposable(value: object): value is object & Disposable {
+  return Symbol.dispose in value &&
+    typeof value[Symbol.dispose] === "function";
+}

--- a/packages/logtape/src/logtape-transport.ts
+++ b/packages/logtape/src/logtape-transport.ts
@@ -82,8 +82,9 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
    *
    * A wrapped transport's `sendMany()` implementation is used directly so
    * provider-specific batching and streaming behavior are preserved.
-   * When iteration stops early, receipts are still drained and logged for
-   * messages that the wrapped transport has already consumed.
+   * Completion logs are emitted as receipts are consumed.  Stopping iteration
+   * early closes the wrapped iterator without draining it, preserving its
+   * cancellation behavior.
    *
    * @param messages Email messages to send.
    * @param options Optional transport options, including cancellation.
@@ -114,28 +115,20 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
       options,
       () => consumedCount++,
     );
-    const receipts = this.wrappedTransport.sendMany(
-      observedMessages,
-      options,
-    )[Symbol.asyncIterator]();
-    let iteratorDone = false;
-    let iteratorFailed = false;
 
     try {
-      while (true) {
-        const result = await receipts.next();
-        if (result.done) {
-          iteratorDone = true;
-          break;
-        }
-
+      for await (
+        const receipt of this.wrappedTransport.sendMany(
+          observedMessages,
+          options,
+        )
+      ) {
         const current = pending.dequeue();
         completedCount++;
-        this.logReceipt(result.value, current, "sendMany");
-        yield result.value;
+        this.logReceipt(receipt, current, "sendMany");
+        yield receipt;
       }
     } catch (error) {
-      iteratorFailed = true;
       this.logBatchThrownError(
         error,
         pending,
@@ -144,16 +137,6 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
         completedCount,
       );
       throw error;
-    } finally {
-      if (!iteratorDone && !iteratorFailed) {
-        await this.drainPendingReceipts(
-          receipts,
-          pending,
-          batchStartedAt,
-          consumedCount,
-          completedCount,
-        );
-      }
     }
   }
 
@@ -326,44 +309,6 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
         batchProperties,
       );
     }
-  }
-
-  private async drainPendingReceipts(
-    receipts: AsyncIterator<Receipt<TProviderId>>,
-    pending: PendingQueue<PendingMessage>,
-    batchStartedAt: number,
-    consumedCount: number,
-    completedCount: number,
-  ): Promise<void> {
-    // Snapshot the backlog so closing this wrapper does not deliberately
-    // extend delivery beyond work that the wrapped transport started.
-    const receiptsToDrain = pending.size;
-    let drainedCount = 0;
-    let iteratorDone = false;
-    try {
-      for (let index = 0; index < receiptsToDrain; index++) {
-        const result = await receipts.next();
-        if (result.done) {
-          iteratorDone = true;
-          break;
-        }
-
-        const current = pending.dequeue();
-        drainedCount++;
-        this.logReceipt(result.value, current, "sendMany");
-      }
-    } catch (error) {
-      this.logBatchThrownError(
-        error,
-        pending,
-        batchStartedAt,
-        consumedCount,
-        completedCount + drainedCount,
-      );
-      throw error;
-    }
-
-    if (!iteratorDone) await receipts.return?.();
   }
 
   private getMessageProperties(message: Message): Record<string, unknown> {

--- a/packages/logtape/src/logtape-transport.ts
+++ b/packages/logtape/src/logtape-transport.ts
@@ -406,11 +406,13 @@ export class LogTapeTransport<TProviderId extends string = "logtape">
 }
 
 function isAsyncDisposable(value: object): value is object & AsyncDisposable {
-  return Symbol.asyncDispose in value &&
+  return typeof Symbol.asyncDispose !== "undefined" &&
+    Symbol.asyncDispose in value &&
     typeof value[Symbol.asyncDispose] === "function";
 }
 
 function isDisposable(value: object): value is object & Disposable {
-  return Symbol.dispose in value &&
+  return typeof Symbol.dispose !== "undefined" &&
+    Symbol.dispose in value &&
     typeof value[Symbol.dispose] === "function";
 }

--- a/packages/logtape/src/pending-queue.test.ts
+++ b/packages/logtape/src/pending-queue.test.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { PendingQueue } from "./pending-queue.ts";
+
+describe("PendingQueue", () => {
+  it("dequeues values in constant-time FIFO order", () => {
+    const queue = new PendingQueue<number>();
+
+    for (let value = 0; value < 10_000; value++) {
+      queue.enqueue(value);
+    }
+
+    for (let value = 0; value < 10_000; value++) {
+      assert.equal(queue.dequeue(), value);
+    }
+    assert.equal(queue.size, 0);
+    assert.equal(queue.dequeue(), undefined);
+  });
+
+  it("iterates only values that have not been dequeued", () => {
+    const queue = new PendingQueue<string>();
+    queue.enqueue("first");
+    queue.enqueue("second");
+    queue.enqueue("third");
+
+    assert.equal(queue.dequeue(), "first");
+    assert.deepEqual([...queue], ["second", "third"]);
+    assert.equal(queue.size, 2);
+  });
+});

--- a/packages/logtape/src/pending-queue.ts
+++ b/packages/logtape/src/pending-queue.ts
@@ -1,0 +1,65 @@
+interface QueueNode<T> {
+  readonly value: T;
+  next?: QueueNode<T>;
+}
+
+/**
+ * Internal linked FIFO queue for messages awaiting delivery receipts.
+ *
+ * Both enqueue and dequeue operations take constant time, without retaining
+ * references to values that have already been dequeued.
+ *
+ * @typeParam T The queued value type.
+ * @since 0.6.0
+ */
+export class PendingQueue<T> implements Iterable<T> {
+  private head?: QueueNode<T>;
+  private tail?: QueueNode<T>;
+  private valueCount = 0;
+
+  /** Number of values waiting in the queue. */
+  get size(): number {
+    return this.valueCount;
+  }
+
+  /**
+   * Adds a value to the end of the queue.
+   *
+   * @param value The value to enqueue.
+   */
+  enqueue(value: T): void {
+    const node: QueueNode<T> = { value };
+    if (this.tail == null) {
+      this.head = node;
+    } else {
+      this.tail.next = node;
+    }
+    this.tail = node;
+    this.valueCount++;
+  }
+
+  /**
+   * Removes and returns the value at the front of the queue.
+   *
+   * @returns The first queued value, or `undefined` when the queue is empty.
+   */
+  dequeue(): T | undefined {
+    const node = this.head;
+    if (node == null) return undefined;
+
+    this.head = node.next;
+    node.next = undefined;
+    this.valueCount--;
+    if (this.head == null) this.tail = undefined;
+    return node.value;
+  }
+
+  /** Iterates over queued values without removing them. */
+  *[Symbol.iterator](): Iterator<T> {
+    let node = this.head;
+    while (node != null) {
+      yield node.value;
+      node = node.next;
+    }
+  }
+}

--- a/packages/logtape/tsdown.config.ts
+++ b/packages/logtape/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: "src/index.ts",
+  dts: true,
+  format: ["esm", "cjs"],
+  platform: "neutral",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@logtape/logtape':
+      specifier: ^2.2.4
+      version: 2.2.4
+    '@logtape/testing':
+      specifier: ^2.2.4
+      version: 2.2.4
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.0
@@ -32,6 +38,9 @@ importers:
 
   docs:
     devDependencies:
+      '@logtape/logtape':
+        specifier: 'catalog:'
+        version: 2.2.4
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.0
@@ -62,6 +71,9 @@ importers:
       '@upyo/lettermint':
         specifier: 'workspace:'
         version: link:../packages/lettermint
+      '@upyo/logtape':
+        specifier: 'workspace:'
+        version: link:../packages/logtape
       '@upyo/maileroo':
         specifier: 'workspace:'
         version: link:../packages/maileroo
@@ -148,6 +160,25 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.12.9(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  packages/logtape:
+    dependencies:
+      '@upyo/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@logtape/logtape':
+        specifier: 'catalog:'
+        version: 2.2.4
+      '@logtape/testing':
+        specifier: 'catalog:'
+        version: 2.2.4(@logtape/logtape@2.2.4)
       tsdown:
         specifier: 'catalog:'
         version: 0.12.9(typescript@5.8.3)
@@ -578,6 +609,14 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
+  '@logtape/logtape@2.2.4':
+    resolution: {integrity: sha512-2rALzv9m4ibE5FyB8/FMm5MPMMlK7ujgy3ufricVKIxj6e7SZbw4w6J16/fRAsXgdDlOXPUA0aa6XoEQvdlKxw==}
+
+  '@logtape/testing@2.2.4':
+    resolution: {integrity: sha512-39NV0o0Awyb1iDdhWuGMSz8a+6CXUZgFpyXV8MtQzXqz2eai0K4cbe4T7axj+o3HV+ArOmMa7Nyn1sDfdYq5EQ==}
+    peerDependencies:
+      '@logtape/logtape': ^2.2.4
 
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
@@ -2014,6 +2053,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@logtape/logtape@2.2.4': {}
+
+  '@logtape/testing@2.2.4(@logtape/logtape@2.2.4)':
+    dependencies:
+      '@logtape/logtape': 2.2.4
 
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ allowBuilds:
   workerd: true
 
 catalog:
+  '@logtape/logtape': ^2.2.4
+  '@logtape/testing': ^2.2.4
   '@opentelemetry/api': ^1.9.0
   '@opentelemetry/resources': ^1.25.1
   '@opentelemetry/sdk-metrics': ^1.25.1


### PR DESCRIPTION
Upyo already supports OpenTelemetry for metrics and traces, while many applications also need ordinary structured logs around email delivery. Local development has a related need: exercising the real mail workflow without handing messages to a provider. `@upyo/logtape` covers both cases through the existing `Transport` interface, so callers do not need a separate development path or logging API.


Why this shape
--------------

`LogTapeTransport` works on its own or as a transparent decorator. On its own, it records the delivery lifecycle and returns a synthetic successful receipt. The application still runs its normal email code, but no message leaves the process.

The constructor type follows the same distinction. Log-only instances are pinned to the `"logtape"` provider id, while choosing another provider type requires a wrapped transport with that id. A standalone transport therefore cannot claim to produce SMTP or API-provider receipts when it actually returns synthetic LogTape receipts.

When another transport is supplied, the wrapper preserves its provider id, receipts, thrown values, abort signal, `sendMany()` implementation, and disposal behavior. The logs surround the real operation instead of changing its result. This also lets LogTape sit beside retry, pool, and OpenTelemetry transports. Their order defines the observation boundary, including whether a set of retries/failovers appears as one logged operation or several.

The package deliberately does not configure LogTape. Applications retain control over sinks, filters, and category thresholds, while the transport only requests a logger under `["upyo"]` by default. The category and the levels for sending, success, and failure events can be changed independently.

Lifecycle records contain delivery metadata such as recipient counts, attachment count, provider, duration, and receipt details. Complete messages are excluded by default because addresses, bodies, headers, and attachments may be sensitive or large. Applications can opt in when their logging and redaction setup is appropriate.


Preserving batch behavior
-------------------------

Decorator mode wraps the incoming iterable and records each sending event as the underlying transport consumes that message. It does not collect the whole batch first, so provider-specific streaming and buffering behavior remains intact.

A linked FIFO queue associates receipts with consumed messages using constant time removal. This matters for transports that consume an entire batch before yielding any receipts. If a batch throws after partial consumption, every consumed message that has not received a receipt gets its own failure record, including its recipient counts and optional full message context.